### PR TITLE
fix(PyrecodesResults): support pyrecodes 0.3 filenames with dynamic calc ID

### DIFF
--- a/RecoveryWidgets/PyrecodesResults.cpp
+++ b/RecoveryWidgets/PyrecodesResults.cpp
@@ -48,6 +48,10 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <QApplication>
 #include <SC_MovieWidget.h>
 #include <QPen>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QFile>
 
 
 #include <SC_MultipleLineChart.h>
@@ -61,7 +65,7 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #endif
 
 PyrecodesResults::PyrecodesResults(QWidget * parent, bool dockable)
-  :SC_ResultsWidget(parent) {
+  :SC_ResultsWidget(parent), displayCalculatorIndex(-1) {
 
   //
   // demand-supply
@@ -179,15 +183,53 @@ PyrecodesResults::PyrecodesResults(QWidget * parent, bool dockable)
 }
 
 int
+PyrecodesResults::findDisplayCalculatorIndex(const QString &workdirPath) {
+
+  QDir workDir(workdirPath);
+  QString configPath = workDir.filePath("SystemConfiguration.json");
+  QFile configFile(configPath);
+  if (!configFile.exists() || !configFile.open(QIODevice::ReadOnly)) {
+    return -1;
+  }
+
+  QByteArray fileData = configFile.readAll();
+  QJsonDocument jsonDoc = QJsonDocument::fromJson(fileData);
+  if (jsonDoc.isNull() || !jsonDoc.isObject()) {
+    return -1;
+  }
+
+  QJsonObject root = jsonDoc.object();
+  if (!root.contains("ResilienceCalculator") || !root["ResilienceCalculator"].isArray()) {
+    return -1;
+  }
+
+  QJsonArray calculators = root["ResilienceCalculator"].toArray();
+  for (int i = 0; i < calculators.size(); ++i) {
+    QJsonObject calc = calculators[i].toObject();
+    if (calc.value("ClassName").toString() != "ReCoDeSCalculator") continue;
+    QJsonObject params = calc.value("Parameters").toObject();
+    if (params.value("Scope").toString() == "All") return i;
+  }
+
+  return -1;
+}
+
+int
 PyrecodesResults::processSupplyDemandUpdate(QString &workdirPath) {
 
   QDir workDir(workdirPath);
   QMap<QString, SC_MLC_ChartData *> *chartData = new QMap<QString, SC_MLC_ChartData *>;
 
-  int resourceCounter = 0;  
+  if (displayCalculatorIndex < 0) {
+    supplyDemandChart->setData(chartData);
+    return 0;
+  }
+
+  QString suffix = QString("_supply_demand_consumption_%1.json").arg(displayCalculatorIndex);
+
   for (const QString &resource : resourceList) {
 
-    QString fileName = workDir.filePath(resource + QString("_supply_demand_consumption.json"));
+    QString fileName = workDir.filePath(resource + suffix);
     SC_MLC_ChartData *resourceChartData = new SC_MLC_ChartData();    
 
     resourceChartData->xLabel = "Days";
@@ -241,29 +283,52 @@ int PyrecodesResults::processResults(QString &outputFile, QString &outputDirPath
 
   //
   // get a list of all workdir there
-  //   - for first dir returned get list of files ending in _supply_demand_consumption.json .. this is resources plotted
-  //   - loop through all workdir building the data needed to plot all the results
-  //   - plot them
+  //   - resolve which ReCoDeS calculator drives the supply/demand UI
+  //   - for first dir returned get list of files matching the supply-
+  //     demand-consumption suffix for that calculator. this is the
+  //     resources plotted
+  //   - loop through all workdir building the data needed to plot all
+  //     the results, then plot them
+  //
 
   // list of workdir
 
   QStringList work_directories = workDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
-  // get list of resources to be plotted & create list of QMap<Qstring, QMap<QString, QLineSeries *>>
-  // & then to map add a new SC_MLC_ChartData for each resource
+  QMap<QString, SC_MLC_ChartData *> multipleLineChartData;
+  QStringList fileList;
 
-  workDir.cd(work_directories[0]);
-  QStringList filters;
-  filters << "*_supply_demand_consumption.json";
-  QStringList fileList = workDir.entryList(filters, QDir::Files);
+  if (work_directories.isEmpty()) {
+    displayCalculatorIndex = -1;
+  } else {
+    // Resolve which ReCoDeSCalculator's output to display by parsing
+    // SystemConfiguration.json from the first workdir.
+    QString firstWorkdirPath = workDir.absoluteFilePath(work_directories[0]);
+    displayCalculatorIndex = findDisplayCalculatorIndex(firstWorkdirPath);
+  }
 
-  QMap<QString, SC_MLC_ChartData *>multipleLineChartData;
-    
-  for (const QString &fileName : fileList) {
-    
-    // Remove the suffix to get resources list
-    if (fileName.endsWith("_supply_demand_consumption.json")) {
-      QString resource = fileName.left(fileName.length() - QString("_supply_demand_consumption.json").length());
+  if (displayCalculatorIndex < 0) {
+    this->infoMessage("PyrecodesResults: no ReCoDeSCalculator with Scope=\"All\" "
+                      "was found in SystemConfiguration.json. Supply Curves and "
+                      "Supply-Demand Curves tabs will be empty for this run.");
+  } else {
+    this->infoMessage(QString("PyrecodesResults: Supply Curves and Supply-Demand "
+                              "Curves will be drawn from calculator index %1 "
+                              "(ReCoDeSCalculator, Scope=\"All\").")
+                      .arg(displayCalculatorIndex));
+
+    // Build resourceList and the chart-data shells from the first workdir's
+    // <resource>_supply_demand_consumption_<displayCalculatorIndex>.json files.
+    QString suffix = QString("_supply_demand_consumption_%1.json").arg(displayCalculatorIndex);
+    QStringList filters;
+    filters << QString("*%1").arg(suffix);
+
+    workDir.cd(work_directories[0]);
+    fileList = workDir.entryList(filters, QDir::Files);
+
+    for (const QString &fileName : fileList) {
+      if (!fileName.endsWith(suffix)) continue;
+      QString resource = fileName.left(fileName.length() - suffix.length());
       resourceList << resource;
       SC_MLC_ChartData *resourceLineData = new SC_MLC_ChartData();
       resourceLineData->xLabel = "Days";
@@ -271,9 +336,9 @@ int PyrecodesResults::processResults(QString &outputFile, QString &outputDirPath
       resourceLineData->title =  resource + QString(" Supply Curve");
       multipleLineChartData.insert(resource, resourceLineData);
     }
+
+    workDir.cdUp();
   }
-  
-  workDir.cdUp();
 
   // loop foreach working dir
 

--- a/RecoveryWidgets/PyrecodesResults.h
+++ b/RecoveryWidgets/PyrecodesResults.h
@@ -106,7 +106,7 @@ private:
 			   QLineSeries *demandSeries =0,
 			   QLineSeries *consumptionSeries =0);
 #else
-  
+
  int readDemandSupplyJSON(QString &filename,
 			   QtCharts::QLineSeries *supplySeries,
 			   QtCharts::QLineSeries *demandSeries =0,
@@ -115,7 +115,14 @@ private:
 
   int processSupplyDemandUpdate(QString &workdirPath);
 
+  // Locate the "display" ReCoDeS calculator inside a workdir's
+  // SystemConfiguration.json. Returns its index (used as the supply-
+  // demand-consumption file suffix), or -1 if no ReCoDeSCalculator
+  // with Scope="All" is configured.
+  int findDisplayCalculatorIndex(const QString &workdirPath);
+
   // data
+  int displayCalculatorIndex;
   QVBoxLayout* layout;
   QDockWidget* curveDockWidget;
   QDockWidget* gifDockWidget;


### PR DESCRIPTION
The Recovery results popup was written when pyrecodes wrote one unsuffixed `<resource>_supply_demand_consumption.json` per resource — a model that worked because pyrecodes 0.2 had only the concept of "one calculator's output per resource." pyrecodes 0.3 changed the contract: the filename now embeds the producing calculator's index (`<resource>_supply_demand_consumption_<calc_id>.json`), because a system can have multiple ReCoDeSCalculators with different scopes (region-wide, per-locality, etc.) each producing its own data for the same resource. The old reader doesn't find any matching files under that new naming and the Supply Curves and Supply-Demand Curves tabs render empty.

Hard-coding the index to 0 would unblock the typical case but is fragile: the calculator ID is the user's positional index into the ResilienceCalculator array in SystemConfiguration.json, so the "region-wide" calculator can land at any index depending on how a user ordered their config.

PyrecodesResults now reads SystemConfiguration.json from the first workdir at result-load time and resolves the display calculator's index by walking the ResilienceCalculator array for the first entry with `ClassName == "ReCoDeSCalculator"` and `Parameters.Scope == "All"`. The Supply Curves and Supply-Demand Curves tabs filter for `*_supply_demand_consumption_<that_index>.json` and read only those files. The Recovery GIFs tab is unchanged — it doesn't depend on calculator output.

If no ReCoDeSCalculator with Scope="All" is found, the popup emits an infoMessage explaining that the chart tabs will be empty and proceeds to populate the GIF tab only. If one is found, an infoMessage names the chosen calculator index for transparency.

Mirror-image lookup logic lives in
SimCenterBackendApplications/modules/performREC/pyrecodes/run_pyrecodes.py (find_display_recodes_calculator) — both sides use the same matching rule (ClassName == "ReCoDeSCalculator" and Scope == "All") so they agree on which file holds the UI's data.