### PR TITLE
pyrecodes UI: full 0.3.0 inputs, templates, Main-file generation, UX polish

### DIFF
--- a/R2D.pri
+++ b/R2D.pri
@@ -412,6 +412,8 @@ HEADERS +=  $$PWD/Events/UI/BedrockDepth.h \
 	    $$PWD/RecoveryWidgets/pyrecodes/PyrecodesComponentLibrary.h \
 	    $$PWD/RecoveryWidgets/pyrecodes/PyrecodesComponent.h \	    
 	    $$PWD/RecoveryWidgets/pyrecodes/PyrecodesLocality.h \	    
+	    $$PWD/RecoveryWidgets/pyrecodes/PyrecodesOptions.h \
+	    $$PWD/RecoveryWidgets/pyrecodes/PyrecodesTemplates.h \
             $$PWD/assetWidgets/InpFileWaterInputWidget.h \	    
 	    $$PWD/assetWidgets/EPANET2.2/include/epanet2.h \
 	    $$PWD/assetWidgets/EPANET2.2/include/epanet2_2.h \

--- a/RecoveryWidgets/pyrecodes/PyrecodesComponent.cpp
+++ b/RecoveryWidgets/pyrecodes/PyrecodesComponent.cpp
@@ -2,7 +2,7 @@
 Copyright 2016-2023, The Regents of the University of California (Regents).
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
@@ -11,31 +11,13 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
-THIS SSensorsTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES Sensors MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPBodiesE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT Sensors SUBSTITUTE GOODS OR SERVICES;
-LBodiesS Sensors USE, DATA, OR PRSensorsITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY Sensors LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT Sensors THE USE Sensors THIS
-SSensorsTWARE, EVEN IF ADVISED Sensors THE PBodiesSIBILITY Sensors SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of the FreeBSD Project.
-
-REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
-THE IMPLIED WARRANTIES Sensors MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPBodiesE.
-THE SSensorsTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS 
-PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, 
-UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
+THE SOFTWARE IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 *************************************************************************** */
 
 
 #include <PyrecodesComponent.h>
+#include <PyrecodesOptions.h>
 #include <SC_FileEdit.h>
 #include <SC_StringLineEdit.h>
 #include <SC_ComboBox.h>
@@ -53,134 +35,235 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <QHeaderView>
 #include <QListWidget>
 #include <QPushButton>
+#include <QComboBox>
 #include <QWidget>
 #include <QJsonDocument>
 #include <QJsonParseError>
+
+// helper: make a QComboBox to drop into a table cell, optionally with a
+// leading blank entry (used where a value is optional in the schema)
+static QComboBox *makeRelationCombo(bool allowEmpty = false) {
+  QComboBox *cb = new QComboBox();
+  if (allowEmpty)
+    cb->addItem("");
+  cb->addItems(PyrecodesOptions::relationTypes());
+  cb->setToolTip("Relation shape: Linear (proportional), Constant (always full),\n"
+		 "Binary (all-or-nothing), Reverse* variants. Leave blank if optional.");
+  return cb;
+}
+
+// helper: read the text of a QComboBox sitting in a table cell (empty if none)
+static QString comboTextAt(QTableWidget *table, int row, int col) {
+  QComboBox *cb = qobject_cast<QComboBox *>(table->cellWidget(row, col));
+  return cb ? cb->currentText() : QString();
+}
+
+static void setComboAt(QTableWidget *table, int row, int col, const QString &value) {
+  QComboBox *cb = qobject_cast<QComboBox *>(table->cellWidget(row, col));
+  if (cb) {
+    int idx = cb->findText(value);
+    cb->setCurrentIndex(idx >= 0 ? idx : 0);
+  }
+}
+
+// helper: attach a tooltip to a table's column header
+static void setHeaderTip(QTableWidget *table, int col, const QString &tip) {
+  if (QTableWidgetItem *h = table->horizontalHeaderItem(col))
+    h->setToolTip(tip);
+}
+
+// helper: make a table's columns user-resizable (drag the header borders) and
+// sized to fit their header labels initially.
+static void setupColumns(QTableWidget *t) {
+  QHeaderView *h = t->horizontalHeader();
+  h->setSectionResizeMode(QHeaderView::Interactive);
+  h->setMinimumSectionSize(40);
+  t->resizeColumnsToContents();
+}
+
+// helper: merge the keys of a JSON-object held in a table cell into obj. Lets
+// the UI round-trip any schema fields it has no dedicated column for (e.g.
+// PostDisasterIncreaseDueToEmergencyCalls on a demand entry).
+static void mergeExtraJson(QTableWidget *t, int row, int col, QJsonObject &obj) {
+  QTableWidgetItem *it = t->item(row, col);
+  if (!it) return;
+  QString s = it->text().trimmed();
+  if (s.isEmpty()) return;
+  QJsonParseError pe;
+  QJsonDocument d = QJsonDocument::fromJson(s.toUtf8(), &pe);
+  if (pe.error == QJsonParseError::NoError && d.isObject()) {
+    QJsonObject extra = d.object();
+    for (const QString &k : extra.keys())
+      obj[k] = extra.value(k);
+  }
+}
+
+// helper: comma-joined non-empty names in column `col` of a table, for the
+// summary shown in the Component Library table's Supply / Demand columns.
+static QString joinedColumnNames(QTableWidget *t, int col) {
+  QStringList names;
+  for (int r = 0; r < t->rowCount(); ++r) {
+    QTableWidgetItem *it = t->item(r, col);
+    if (it && !it->text().trimmed().isEmpty())
+      names << it->text().trimmed();
+  }
+  return names.join(", ");
+}
+
+// helper: collect keys of obj not in `known` into a compact JSON-object string
+// (empty if there are none), for display in an "Other (JSON)" cell.
+static QString extraJsonString(const QJsonObject &obj, const QStringList &known) {
+  QJsonObject extra;
+  for (const QString &k : obj.keys())
+    if (!known.contains(k))
+      extra[k] = obj.value(k);
+  if (extra.isEmpty())
+    return QString();
+  return QString(QJsonDocument(extra).toJson(QJsonDocument::Compact));
+}
 
 PyrecodesComponent::PyrecodesComponent(QString initName, PyrecodesComponentLibrary *theCL, QWidget *parent)
   :SimCenterWidget(parent), theComponentLibrary(theCL)
 {
   theName = new QLineEdit("name");
   theName->setText(initName);
+  theName->setToolTip("Unique component name. This is the name you reference from the\n"
+		      "System Configuration (Localities and distribution priorities),\n"
+		      "e.g. ElectricPowerPlant, BuildingStockUnit.");
 
-  QStringList classTypes;
-  classTypes << "StandardiReCoDeSComponent"
-	     << "BuildingWithEmergencyCalls"
-	     << "InfrastructureInterface"
-	     << "R2DBridge"
-	     << "R2DTunnel"
-	     << "R2DRoadway"
-	     << "R2DPipe";
-  
-  theClass = new SC_ComboBox("componentClass", classTypes);
+  // Component class - full pyrecodes 0.3.0 list
+  theClass = new SC_ComboBox("componentClass", PyrecodesOptions::componentClasses());
+  theClass->setToolTip("pyrecodes component class.\n"
+		       "  StandardiReCoDeSComponent - generic supplier/consumer component\n"
+		       "  InfrastructureInterface   - boundary between subsystems\n"
+		       "  R2DBuilding/R2DBridge/...  - use these when running from R2DTool\n"
+		       "                               (built from the R2D exposure file).");
 
   //
   // Recovery Relation & Table
   //
 
-  QStringList recoveryTypes;
-  recoveryTypes << "NoRecoveryActivityModel"
-		<< "ComponentLevelRecoveryActivitiesModel"
-		<< "InfrastructureInterfaceRecoveryModel";
-  
-  theRecoveryType = new SC_ComboBox("recoveryType", recoveryTypes);
-  
-  QStringList functionTypes;
-  functionTypes << ""
-		<< "Constant"
-		<< "ReverseBinary"
-		<< "MultipleSteps";
-  
-  theDamageFunctionalRelation = new SC_ComboBox("damageRelation", functionTypes);
+  theRecoveryType = new SC_ComboBox("recoveryType", PyrecodesOptions::recoveryModelClasses());
+  theRecoveryType->setToolTip("How the component recovers after damage.\n"
+			      "  NoRecoveryActivityModel                - never changes (no repair)\n"
+			      "  ComponentLevelRecoveryActivitiesModel  - repaired via the recovery activities below\n"
+			      "  InfrastructureInterfaceRecoveryModel   - recovery follows the connected subsystem.");
 
-  
-  QStringList headingsRecovery; headingsRecovery << "Recovery Activity" << "Pure Execution Time" << "Resources Needed" << "PreceedingActivities";
+  // Damage->functionality relation type (real relation classes)
+  theDamageFunctionalRelation = new SC_ComboBox("damageRelation", PyrecodesOptions::relationTypes());
+  theDamageFunctionalRelation->setToolTip("Maps damage/repair progress to functionality (0..1).\n"
+			      "  ReverseBinary - functional only once fully repaired (0 until done, then 1)\n"
+			      "  Linear        - functionality recovers proportionally to repair progress\n"
+			      "  Constant      - functionality is independent of damage.");
+
+  QStringList headingsRecovery;
+  headingsRecovery << "Recovery Activity" << "Duration" << "Demand" << "Preceding Activities";
   theRecoveryTable = new QTableWidget();
   theRecoveryTable->setColumnCount(4);
   theRecoveryTable->setHorizontalHeaderLabels(headingsRecovery);
-  theRecoveryTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  setupColumns(theRecoveryTable);
   theRecoveryTable->verticalHeader()->setVisible(false);
   theRecoveryTable->setShowGrid(true);
-  theRecoveryTable->setStyleSheet("QTableWidget::item { border: 1px solid black; }");
+  theRecoveryTable->setAlternatingRowColors(true);
+  setHeaderTip(theRecoveryTable, 0, "Name of the repair step, e.g. RapidInspection, Repair, CleanUp.");
+  setHeaderTip(theRecoveryTable, 1, "Duration as a probability distribution (JSON), e.g.\n"
+		"  {\"Deterministic\": {\"Value\": 10}}  or\n"
+		"  {\"Lognormal\": {\"Median\": 30, \"Dispersion\": 0.4}}   (units = time steps)");
+  setHeaderTip(theRecoveryTable, 2, "Resources this step consumes (JSON array), e.g.\n"
+		"  [{\"Resource\": \"RepairCrew\", \"Amount\": 1}]   Use [] if none.");
+  setHeaderTip(theRecoveryTable, 3, "Steps that must finish first (JSON array of activity names),\n"
+		"  e.g. [\"RapidInspection\"].  Use [] for none.");
 
-  QPushButton *addRecoveryButton = new QPushButton("Add Demand");
+  QPushButton *addRecoveryButton = new QPushButton("Add Recovery Activity");
+  addRecoveryButton->setToolTip("Add a repair step. A row is pre-filled with a valid example you can edit.");
   connect(addRecoveryButton, &QPushButton::clicked, this, [=]() {
-    // add a row
     int row = theRecoveryTable->rowCount();
     theRecoveryTable->insertRow(row);
-    for (int col = 0; col < 2; ++col) {
-      QTableWidgetItem *item = new QTableWidgetItem(""); // Empty cell
-      theRecoveryTable->setItem(row, col, item);
-    }
-  });      
+    // pre-fill with valid 0.3.0 templates so the user sees the expected shape
+    theRecoveryTable->setItem(row, 0, new QTableWidgetItem("Repair"));
+    theRecoveryTable->setItem(row, 1, new QTableWidgetItem("{\"Lognormal\": {\"Median\": 10, \"Dispersion\": 0.3}}"));
+    theRecoveryTable->setItem(row, 2, new QTableWidgetItem("[{\"Resource\": \"RepairCrew\", \"Amount\": 1}]"));
+    theRecoveryTable->setItem(row, 3, new QTableWidgetItem("[]"));
+  });
 
   //
   // Supply Table
   //
-  
-  QStringList headingsSupply; headingsSupply << "Resource Name" << "Resource Amount" << "Functionality to Amount Relation" << "Unmet Demand To Amount Relation";
+
+  QStringList headingsSupply;
+  headingsSupply << "Resource Name" << "Amount" << "Functionality To Amount Relation"
+		 << "Unmet Demand To Amount Relation" << "Other (JSON)";
   theSupplyTable = new QTableWidget();
-  theSupplyTable->setColumnCount(4);
+  theSupplyTable->setColumnCount(5);
   theSupplyTable->setHorizontalHeaderLabels(headingsSupply);
-  theSupplyTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  setupColumns(theSupplyTable);
   theSupplyTable->verticalHeader()->setVisible(false);
   theSupplyTable->setShowGrid(true);
-  theSupplyTable->setStyleSheet("QTableWidget::item { border: 1px solid black; }");        
+  theSupplyTable->setAlternatingRowColors(true);
+  setHeaderTip(theSupplyTable, 0, "Resource this component provides, e.g. ElectricPower, Communication.\n"
+		"Must match a resource name defined in the System Configuration.");
+  setHeaderTip(theSupplyTable, 1, "Maximum amount supplied when fully functional (a number).");
+  setHeaderTip(theSupplyTable, 2, "How supply scales with the component's functionality:\n"
+		"  Linear = proportional, Constant = always full, Binary = all-or-nothing.");
+  setHeaderTip(theSupplyTable, 3, "Optional: how supply scales when the component's own demand is unmet.\n"
+		"Leave blank if not applicable.");
+  setHeaderTip(theSupplyTable, 4, "Optional: any extra keys for this entry as a JSON object, e.g.\n"
+		"  {\"PostDisasterIncreaseDueToEmergencyCalls\": \"True\"}. Use {} or leave blank if none.");
 
-  QPushButton *addSupplyButton = new QPushButton("Add Demand");
+  QPushButton *addSupplyButton = new QPushButton("Add Supply");
+  addSupplyButton->setToolTip("Add a resource this component supplies to the community.");
   connect(addSupplyButton, &QPushButton::clicked, this, [=]() {
-
     int row = theSupplyTable->rowCount();
     theSupplyTable->insertRow(row);
-    QTableWidgetItem *name = new QTableWidgetItem(""); // Empty cell
-    theSupplyTable->setItem(row, 0, name);
-    QTableWidgetItem *amount = new QTableWidgetItem(""); // Empty cell
-    theSupplyTable->setItem(row, 1, amount);            
-    QComboBox *functionalityAmount = new QComboBox();
-    functionalityAmount->addItems({"FA 1", "FA 2", "FA 3"});
-    theSupplyTable->setCellWidget(row, 2, functionalityAmount);
-    QComboBox *unmetDemandAmount = new QComboBox();
-    unmetDemandAmount->addItems({"UDA 1", "UDA 2", "UDA 3"});
-    theSupplyTable->setCellWidget(row, 3, unmetDemandAmount);            
-  });      
+    theSupplyTable->setItem(row, 0, new QTableWidgetItem(""));
+    theSupplyTable->setItem(row, 1, new QTableWidgetItem("1"));
+    theSupplyTable->setCellWidget(row, 2, makeRelationCombo(false));        // FunctionalityToAmountRelation
+    theSupplyTable->setCellWidget(row, 3, makeRelationCombo(true));         // UnmetDemandToAmountRelation (optional)
+    theSupplyTable->setItem(row, 4, new QTableWidgetItem(""));              // Other keys (JSON)
+  });
 
   //
   // OpDemandTable
   //
 
-  QStringList headingsOpDemand; headingsOpDemand << "Resource Name" << "Resource Amount" << "Functionality to Amount Relation";
+  QStringList headingsOpDemand;
+  headingsOpDemand << "Resource Name" << "Amount" << "Functionality To Amount Relation" << "Other (JSON)";
   theOpDemandTable = new QTableWidget();
-  theOpDemandTable->setColumnCount(3);
+  theOpDemandTable->setColumnCount(4);
   theOpDemandTable->setHorizontalHeaderLabels(headingsOpDemand);
-  theOpDemandTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  setupColumns(theOpDemandTable);
   theOpDemandTable->verticalHeader()->setVisible(false);
   theOpDemandTable->setShowGrid(true);
-  theOpDemandTable->setStyleSheet("QTableWidget::item { border: 1px solid black; }");
+  theOpDemandTable->setAlternatingRowColors(true);
+  setHeaderTip(theOpDemandTable, 0, "Resource this component needs to operate, e.g. ElectricPower.\n"
+		"Must match a resource name defined in the System Configuration.");
+  setHeaderTip(theOpDemandTable, 1, "Amount required for full operation (a number).");
+  setHeaderTip(theOpDemandTable, 2, "How the demand scales with functionality (usually Linear).");
+  setHeaderTip(theOpDemandTable, 3, "Optional: any extra keys for this entry as a JSON object, e.g.\n"
+		"  {\"PostDisasterIncreaseDueToEmergencyCalls\": \"True\"}. Use {} or leave blank if none.");
 
-  // button and connection to add an OpDemand
-  QPushButton *addOpDemandButton = new QPushButton("Add Demand");
+  QPushButton *addOpDemandButton = new QPushButton("Add Operation Demand");
+  addOpDemandButton->setToolTip("Add a resource this component consumes to stay operational.");
   connect(addOpDemandButton, &QPushButton::clicked, this, [=]() {
     int row = theOpDemandTable->rowCount();
     theOpDemandTable->insertRow(row);
-    QTableWidgetItem *name = new QTableWidgetItem(""); // Empty cell
-    theOpDemandTable->setItem(row, 0, name);
-    QTableWidgetItem *amount = new QTableWidgetItem(""); // Empty cell
-    theOpDemandTable->setItem(row, 1, amount);            
-    QComboBox *functionality = new QComboBox();
-    functionality->addItems({"Demand Option 1", "Demand Option 2", "Demand Option 3"});
-    theOpDemandTable->setCellWidget(row, 2, functionality);
-  });    
-  
-  
+    theOpDemandTable->setItem(row, 0, new QTableWidgetItem(""));
+    theOpDemandTable->setItem(row, 1, new QTableWidgetItem("1"));
+    theOpDemandTable->setCellWidget(row, 2, makeRelationCombo(false));
+    theOpDemandTable->setItem(row, 3, new QTableWidgetItem(""));
+  });
+
+
   QPushButton *doneButton = new QPushButton("Done");
   connect(doneButton, &QPushButton::clicked, this, [=]() {
     theComponentLibrary->addOrUpdateComponentTableEntry(theName->text(),
 							theClass->currentText(),
-							theDamageFunctionalRelation->currentText(),
-							QString(""),QString(""));
+							joinedColumnNames(theSupplyTable, 0),
+							joinedColumnNames(theOpDemandTable, 0),
+							theRecoveryType->currentText());
     // close the widget
     this->close();
-  });  
+  });
 
 
   //
@@ -188,46 +271,48 @@ PyrecodesComponent::PyrecodesComponent(QString initName, PyrecodesComponentLibra
   //
 
   int numRow = 0;
-  
+
   QGridLayout *layout = new QGridLayout();
+
+  QLabel *intro = new QLabel(
+      "Define one component (asset type). Set its class, what it supplies and needs, "
+      "and how it recovers. Hover any field or column header for help. Click Done when finished.");
+  intro->setWordWrap(true);
+  intro->setStyleSheet("color: #555; font-style: italic;");
+  layout->addWidget(intro, numRow++, 0, 1, 2);
+
   layout->addWidget(new QLabel("Name:"), numRow, 0);
   layout->addWidget(theName, numRow++, 1);
 
   layout->addWidget(new QLabel("Component Class:"), numRow, 0);
-  layout->addWidget(theClass, numRow++, 1);  
+  layout->addWidget(theClass, numRow++, 1);
 
-  // try group box
-  bool groupBox = true;
-  if (groupBox == true) {
+  QGroupBox *groupRecovery = new QGroupBox("Recovery Model");
+  QGridLayout *groupRecoveryLayout = new QGridLayout(groupRecovery);
+  groupRecoveryLayout->addWidget(new QLabel("Recovery Type:"), 0, 0);
+  groupRecoveryLayout->addWidget(theRecoveryType, 0, 1);
+  groupRecoveryLayout->addWidget(new QLabel("Damage Functionality Relation:"), 1, 0);
+  groupRecoveryLayout->addWidget(theDamageFunctionalRelation, 1, 1);
+  groupRecoveryLayout->addWidget(addRecoveryButton, 2, 0);
+  groupRecoveryLayout->addWidget(theRecoveryTable, 3, 0, 1, 4);
 
-    QGroupBox *groupRecovery = new QGroupBox("Recovery Model");
-    QGridLayout *groupRecoveryLayout = new QGridLayout(groupRecovery);
-    groupRecoveryLayout->addWidget(new QLabel("RecoveryType:"), 0, 0);
-    groupRecoveryLayout->addWidget(theRecoveryType, 0, 1);        
-    groupRecoveryLayout->addWidget(new QLabel("Damage Functional Recovery:"), 1, 0);
-    groupRecoveryLayout->addWidget(theDamageFunctionalRelation, 1, 1);    
-    groupRecoveryLayout->addWidget(addRecoveryButton, 2, 0);
-    groupRecoveryLayout->addWidget(theRecoveryTable, 3, 0, 1, 4);
-    
-    QGroupBox *groupSupply = new QGroupBox("Supply");
-    QGridLayout *groupSupplyLayout = new QGridLayout(groupSupply);  
-    groupSupplyLayout->addWidget(addSupplyButton, 0, 0);
-    groupSupplyLayout->addWidget(theSupplyTable, 1, 0, 1, 4);
+  QGroupBox *groupSupply = new QGroupBox("Supply");
+  QGridLayout *groupSupplyLayout = new QGridLayout(groupSupply);
+  groupSupplyLayout->addWidget(addSupplyButton, 0, 0);
+  groupSupplyLayout->addWidget(theSupplyTable, 1, 0, 1, 4);
 
-    QGroupBox *groupOpDemand = new QGroupBox("Operational Demand");
-    QGridLayout *groupOpDemandLayout = new QGridLayout(groupOpDemand);  
-    groupOpDemandLayout->addWidget(addOpDemandButton, 0, 0);
-    groupOpDemandLayout->addWidget(theOpDemandTable, 1, 0, 1, 4);
+  QGroupBox *groupOpDemand = new QGroupBox("Operation Demand");
+  QGridLayout *groupOpDemandLayout = new QGridLayout(groupOpDemand);
+  groupOpDemandLayout->addWidget(addOpDemandButton, 0, 0);
+  groupOpDemandLayout->addWidget(theOpDemandTable, 1, 0, 1, 4);
 
-    layout->addWidget(groupSupply, numRow++, 0, 1, 4);
-    layout->addWidget(groupOpDemand, numRow++, 0, 1, 4);
-    layout->addWidget(groupRecovery, numRow++, 0, 1, 4);
-    
-  }
+  layout->addWidget(groupSupply, numRow++, 0, 1, 4);
+  layout->addWidget(groupOpDemand, numRow++, 0, 1, 4);
+  layout->addWidget(groupRecovery, numRow++, 0, 1, 4);
 
   layout->addWidget(doneButton, numRow++, 1, 1, 2);
-  layout->setRowStretch(4,1);
-  
+  layout->setRowStretch(numRow, 1);
+
   this->setLayout(layout);
 }
 
@@ -248,121 +333,138 @@ PyrecodesComponent::outputToJSON(QJsonObject &jsonObject)
 
   QJsonObject componentObject;
 
+  // ComponentClass: ClassName + FileName (pyrecodes 0.3.0)
   QJsonObject componentClass;
-  componentClass["ClassName"] = theClass->currentText();
-  componentObject["ComponentClass"] = componentClass;  
+  QString className = theClass->currentText();
+  componentClass["ClassName"] = className;
+  QString classFile = PyrecodesOptions::fileNameForClass(className);
+  if (!classFile.isEmpty())
+    componentClass["FileName"] = classFile;
+  componentObject["ComponentClass"] = componentClass;
 
   //
   // Fill in supplyObject
   //
-  
+
   QJsonObject supplyObject;
   int numRows = theSupplyTable->rowCount();
-  
-  for (int i=0; i<numRows; i++) {
+
+  for (int i = 0; i < numRows; i++) {
 
     QJsonObject obj;
-    QTableWidgetItem *nameItem = theSupplyTable->item(i, 0);    
-    QTableWidgetItem *amountItem = theSupplyTable->item(i, 1);    
-    QTableWidgetItem *ftarItem = theSupplyTable->item(i, 2);
-    QTableWidgetItem *udtarItem = theSupplyTable->item(i, 3);
-    
+    QTableWidgetItem *nameItem = theSupplyTable->item(i, 0);
+    QTableWidgetItem *amountItem = theSupplyTable->item(i, 1);
+    if (nameItem == nullptr || nameItem->text().isEmpty())
+      continue;
+
     QString name = nameItem->text();
-    QString udtar = udtarItem->text();
     bool ok;
-    obj["Amount"] = amountItem->text().toDouble(&ok);
-    obj["FunctionalityToAmountRelation"] = ftarItem->text();
-    if (!udtar.isEmpty() && !udtar.isNull())
+    obj["Amount"] = amountItem ? amountItem->text().toDouble(&ok) : 0.0;
+    obj["FunctionalityToAmountRelation"] = comboTextAt(theSupplyTable, i, 2);
+    QString udtar = comboTextAt(theSupplyTable, i, 3);
+    if (!udtar.isEmpty())
       obj["UnmetDemandToAmountRelation"] = udtar;
+    mergeExtraJson(theSupplyTable, i, 4, obj);   // any extra schema keys
     supplyObject[name] = obj;
-    
   }
 
   componentObject["Supply"] = supplyObject;
-  
+
   //
   // parse op demand
-  // 
+  //
 
   QJsonObject opDemandObject;
-  
-  numRows = theOpDemandTable->rowCount();
-  for (int i=0; i<numRows; i++) {
-    
-    QJsonObject obj;
 
+  numRows = theOpDemandTable->rowCount();
+  for (int i = 0; i < numRows; i++) {
+
+    QJsonObject obj;
     QTableWidgetItem *nameItem = theOpDemandTable->item(i, 0);
     QTableWidgetItem *amountItem = theOpDemandTable->item(i, 1);
-    QTableWidgetItem *ftarItem = theOpDemandTable->item(i, 2);
-    
+    if (nameItem == nullptr || nameItem->text().isEmpty())
+      continue;
+
     QString name = nameItem->text();
     bool ok;
-    obj["Amount"] = amountItem->text().toDouble(&ok);    
-    obj["FunctionalityToAmountRelation"] = ftarItem->text();
+    obj["Amount"] = amountItem ? amountItem->text().toDouble(&ok) : 0.0;
+    obj["FunctionalityToAmountRelation"] = comboTextAt(theOpDemandTable, i, 2);
+    mergeExtraJson(theOpDemandTable, i, 3, obj);   // any extra schema keys
     opDemandObject[name] = obj;
-    
   }
 
-  // only ouput if nothing there
-  if (numRows != 0)
+  if (!opDemandObject.isEmpty())
     componentObject["OperationDemand"] = opDemandObject;
-  
+
   //
   // parse recovery model
-  // 
+  //
 
   QJsonObject recObject;
-  
-  recObject["ClassName"] = theRecoveryType->currentText();
 
+  QString recoveryClass = theRecoveryType->currentText();
+  recObject["ClassName"] = recoveryClass;
+  QString recoveryFile = PyrecodesOptions::fileNameForClass(recoveryClass);
+  if (!recoveryFile.isEmpty())
+    recObject["FileName"] = recoveryFile;
 
   QJsonObject damageFunctionalityRelation;
   damageFunctionalityRelation["Type"] = theDamageFunctionalRelation->currentText();
-  recObject["DamageFunctionalityRelation"] = damageFunctionalityRelation;  
+  recObject["DamageFunctionalityRelation"] = damageFunctionalityRelation;
 
+  // Parameters: one entry per recovery activity
+  //   <ActivityName>: { Duration:{<dist>:{...}}, Demand:[...], PrecedingActivities:[...] }
   QJsonObject parametersObject;
 
   numRows = theRecoveryTable->rowCount();
-  for (int i=0; i<numRows; i++) {
-    QJsonObject obj;
-
+  for (int i = 0; i < numRows; i++) {
     QTableWidgetItem *nameItem = theRecoveryTable->item(i, 0);
     QTableWidgetItem *durationItem = theRecoveryTable->item(i, 1);
     QTableWidgetItem *demandItem = theRecoveryTable->item(i, 2);
-    QTableWidgetItem *precedingItem = theRecoveryTable->item(i, 3);            
-    
+    QTableWidgetItem *precedingItem = theRecoveryTable->item(i, 3);
+
+    if (nameItem == nullptr || nameItem->text().isEmpty())
+      continue;
     QString name = nameItem->text();
+
+    QJsonObject obj;
     QJsonParseError parseError;
 
-    QJsonArray demandArray;
     QJsonObject durationObject;
-    QJsonArray precedingArray;
-    
-    QJsonDocument jsonDocDemand = QJsonDocument::fromJson(demandItem->text().toUtf8(), &parseError);
-    if (jsonDocDemand.isArray()) 
-      demandArray = jsonDocDemand.array();
-    QJsonDocument jsonDocDuration = QJsonDocument::fromJson(durationItem->text().toUtf8(), &parseError);
-    if (jsonDocDuration.isObject()) 
-      durationObject = jsonDocDemand.object();
-    QJsonDocument jsonDocPreceding = QJsonDocument::fromJson(precedingItem->text().toUtf8(), &parseError);
-    if (jsonDocPreceding.isArray()) 
-      precedingArray = jsonDocPreceding.array();		
-    
-    obj["Duration"] = durationObject;
-    obj["Demand"] = demandArray;	
-    obj["PrecedingActivities"]  = precedingArray;
-    
-    parametersObject[name] = obj;
+    if (durationItem) {
+      QJsonDocument jsonDocDuration = QJsonDocument::fromJson(durationItem->text().toUtf8(), &parseError);
+      if (jsonDocDuration.isObject())
+	durationObject = jsonDocDuration.object();
+    }
 
+    QJsonArray demandArray;
+    if (demandItem) {
+      QJsonDocument jsonDocDemand = QJsonDocument::fromJson(demandItem->text().toUtf8(), &parseError);
+      if (jsonDocDemand.isArray())
+	demandArray = jsonDocDemand.array();
+    }
+
+    QJsonArray precedingArray;
+    if (precedingItem) {
+      QJsonDocument jsonDocPreceding = QJsonDocument::fromJson(precedingItem->text().toUtf8(), &parseError);
+      if (jsonDocPreceding.isArray())
+	precedingArray = jsonDocPreceding.array();
+    }
+
+    obj["Duration"] = durationObject;
+    obj["Demand"] = demandArray;
+    obj["PrecedingActivities"] = precedingArray;
+
+    parametersObject[name] = obj;
   }
-  
+
   recObject["Parameters"] = parametersObject;
 
   componentObject["RecoveryModel"] = recObject;
-  
-  QString name = theName->text();  
-  jsonObject[name] = componentObject;  
-  
+
+  QString name = theName->text();
+  jsonObject[name] = componentObject;
+
   return true;
 }
 
@@ -373,10 +475,10 @@ PyrecodesComponent::inputFromJSON(QJsonObject &jsonObject)
   //
   // parse component class
   //
-  
+
   QJsonValue componentValue = jsonObject["ComponentClass"];
   if (!componentValue.isNull() && componentValue.isObject()) {
-    
+
     QJsonObject componentObject = componentValue.toObject();
     QJsonValue compObjectClassValue = componentObject["ClassName"];
     if (!compObjectClassValue.isNull() && compObjectClassValue.isString()) {
@@ -390,44 +492,47 @@ PyrecodesComponent::inputFromJSON(QJsonObject &jsonObject)
 
   //
   // parse supply
-  // 
+  //
 
-  theSupplyTable->clearContents();
+  theSupplyTable->setRowCount(0);
   QJsonValue supplyValue = jsonObject["Supply"];
-  
+
   if (!supplyValue.isNull() && supplyValue.isObject()) {
-    
+
     QJsonObject supplyObject = supplyValue.toObject();
-    theSupplyTable->setRowCount(supplyObject.size());  
 
     int row = 0;
     for (const QString &key : supplyObject.keys()) {
-      
+
       QJsonValue value = supplyObject.value(key);
       if (!value.isNull() && value.isObject()) {
 	QJsonObject obj = value.toObject();
-	
+
 	QString amount, ftar, udtar;
 	QJsonValue amountValue = obj["Amount"];
 	QJsonValue ftarValue = obj["FunctionalityToAmountRelation"];
 	QJsonValue udtarValue = obj["UnmetDemandToAmountRelation"];
-	
-	if (!amountValue.isNull() && amountValue.isDouble()) 
+
+	if (!amountValue.isNull() && amountValue.isDouble())
 	  amount = QString::number(amountValue.toDouble());
 	if (!ftarValue.isNull() && ftarValue.isString())
 	  ftar = ftarValue.toString();
 	if (!udtarValue.isNull() && udtarValue.isString())
 	  udtar = udtarValue.toString();
-	
-	QTableWidgetItem *newName = new QTableWidgetItem(key);      
-	QTableWidgetItem *newAmount = new QTableWidgetItem(amount);
-	QTableWidgetItem *newFTAR = new QTableWidgetItem(ftar);
-	QTableWidgetItem *newUDTAR = new QTableWidgetItem(udtar);
-	theSupplyTable->setItem(row, 0, newName);
-	theSupplyTable->setItem(row, 1, newAmount);
-	theSupplyTable->setItem(row, 2, newFTAR);
-	theSupplyTable->setItem(row, 3, newUDTAR);
-	
+
+	QString extra = extraJsonString(obj, QStringList()
+					<< "Amount" << "FunctionalityToAmountRelation"
+					<< "UnmetDemandToAmountRelation");
+
+	theSupplyTable->insertRow(row);
+	theSupplyTable->setItem(row, 0, new QTableWidgetItem(key));
+	theSupplyTable->setItem(row, 1, new QTableWidgetItem(amount));
+	theSupplyTable->setCellWidget(row, 2, makeRelationCombo(false));
+	theSupplyTable->setCellWidget(row, 3, makeRelationCombo(true));
+	setComboAt(theSupplyTable, row, 2, ftar);
+	setComboAt(theSupplyTable, row, 3, udtar);
+	theSupplyTable->setItem(row, 4, new QTableWidgetItem(extra));
+
 	row++;
       }
     }
@@ -435,39 +540,41 @@ PyrecodesComponent::inputFromJSON(QJsonObject &jsonObject)
 
   //
   // parse op demand
-  // 
+  //
 
-  theOpDemandTable->clearContents();
+  theOpDemandTable->setRowCount(0);
   QJsonValue odValue = jsonObject["OperationDemand"];
-  
+
   if (!odValue.isNull() && odValue.isObject()) {
-    
+
     QJsonObject odObject = odValue.toObject();
-    theOpDemandTable->setRowCount(odObject.size());  
 
     int row = 0;
     for (const QString &key : odObject.keys()) {
-      
+
       QJsonValue value = odObject.value(key);
       if (!value.isNull() && value.isObject()) {
 	QJsonObject obj = value.toObject();
-	
+
 	QString amount, ftar;
 	QJsonValue amountValue = obj["Amount"];
 	QJsonValue ftarValue = obj["FunctionalityToAmountRelation"];
-	
-	if (!amountValue.isNull() && amountValue.isDouble()) 
+
+	if (!amountValue.isNull() && amountValue.isDouble())
 	  amount = QString::number(amountValue.toDouble());
 	if (!ftarValue.isNull() && ftarValue.isString())
 	  ftar = ftarValue.toString();
-	
-	QTableWidgetItem *newName = new QTableWidgetItem(key);      
-	QTableWidgetItem *newAmount = new QTableWidgetItem(amount);
-	QTableWidgetItem *newFTAR = new QTableWidgetItem(ftar);
-	theOpDemandTable->setItem(row, 0, newName);
-	theOpDemandTable->setItem(row, 1, newAmount);
-	theOpDemandTable->setItem(row, 2, newFTAR);
-	
+
+	QString extra = extraJsonString(obj, QStringList()
+					<< "Amount" << "FunctionalityToAmountRelation");
+
+	theOpDemandTable->insertRow(row);
+	theOpDemandTable->setItem(row, 0, new QTableWidgetItem(key));
+	theOpDemandTable->setItem(row, 1, new QTableWidgetItem(amount));
+	theOpDemandTable->setCellWidget(row, 2, makeRelationCombo(false));
+	setComboAt(theOpDemandTable, row, 2, ftar);
+	theOpDemandTable->setItem(row, 3, new QTableWidgetItem(extra));
+
 	row++;
       }
     }
@@ -476,40 +583,33 @@ PyrecodesComponent::inputFromJSON(QJsonObject &jsonObject)
 
   //
   // parse recovery model
-  // 
+  //
 
-  theRecoveryTable->clearContents();
+  theRecoveryTable->setRowCount(0);
   QJsonValue recoveryValue = jsonObject["RecoveryModel"];
-  
+
   if (!recoveryValue.isNull() && recoveryValue.isObject()) {
-    
+
     QJsonObject recoveryObject = recoveryValue.toObject();
 
     // type
-    QString className;
     QJsonValue classValue = recoveryObject["ClassName"];
     if (!classValue.isNull() && classValue.isString()) {
-      className = classValue.toString();
-      int index = theRecoveryType->findText(className);
-      if (index != -1) {
+      int index = theRecoveryType->findText(classValue.toString());
+      if (index != -1)
 	theRecoveryType->setCurrentIndex(index);
-      }
     }
 
-
     // damage functional relation
-    QString dfrName;
     QJsonValue dfrValue = recoveryObject["DamageFunctionalityRelation"];
     if (!dfrValue.isNull() && dfrValue.isObject()) {
       QJsonValue typeValue = dfrValue.toObject()["Type"];
       if (!typeValue.isNull() && typeValue.isString()) {
-	dfrName = typeValue.toString();
-	int index = theDamageFunctionalRelation->findText(dfrName);
-	if (index != -1) {
+	int index = theDamageFunctionalRelation->findText(typeValue.toString());
+	if (index != -1)
 	  theDamageFunctionalRelation->setCurrentIndex(index);
-	}
       }
-    }    
+    }
 
     QJsonValue parametersValue = recoveryObject["Parameters"];
     QJsonObject parametersObject;
@@ -519,52 +619,48 @@ PyrecodesComponent::inputFromJSON(QJsonObject &jsonObject)
     //
     // fill in the recovery table
     //
-    
-    int row = 0;
-    theRecoveryTable->setRowCount(parametersObject.size());  
 
+    int row = 0;
     for (const QString &key : parametersObject.keys()) {
 
       QJsonValue value = parametersObject.value(key);
       if (!value.isNull() && value.isObject()) {
 	QJsonObject obj = value.toObject();
-	
-	QString duration, demand, proceedingActivities;
-	QJsonValue durationValue = obj["Duration"];
-	QJsonValue demandValue = obj["Demand"];	
-	QJsonValue preceedingValue = obj["PrecedingActivities"];
-	
-	if (!durationValue.isNull() && durationValue.isObject()) 
-	  duration = QString(QJsonDocument(durationValue.toObject()).toJson(QJsonDocument::Compact));
-	if (!demandValue.isNull() && demandValue.isArray()) 
-	  demand = QString(QJsonDocument(demandValue.toArray()).toJson(QJsonDocument::Compact));
-	if (!preceedingValue.isNull() && preceedingValue.isArray()) 
-	  proceedingActivities = QString(QJsonDocument(preceedingValue.toArray()).toJson(QJsonDocument::Compact));
 
-	QTableWidgetItem *newName = new QTableWidgetItem(key);      	
-	QTableWidgetItem *newDuration = new QTableWidgetItem(duration);      
-	QTableWidgetItem *newDemand = new QTableWidgetItem(demand);
-	QTableWidgetItem *newProceeding = new QTableWidgetItem(proceedingActivities);
-	theRecoveryTable->setItem(row, 0, newName);	
-	theRecoveryTable->setItem(row, 1, newDuration);
-	theRecoveryTable->setItem(row, 2, newDemand);
-	theRecoveryTable->setItem(row, 3, newProceeding);
-	
+	QString duration, demand, precedingActivities;
+	QJsonValue durationValue = obj["Duration"];
+	QJsonValue demandValue = obj["Demand"];
+	QJsonValue precedingValue = obj["PrecedingActivities"];
+
+	if (!durationValue.isNull() && durationValue.isObject())
+	  duration = QString(QJsonDocument(durationValue.toObject()).toJson(QJsonDocument::Compact));
+	if (!demandValue.isNull() && demandValue.isArray())
+	  demand = QString(QJsonDocument(demandValue.toArray()).toJson(QJsonDocument::Compact));
+	if (!precedingValue.isNull() && precedingValue.isArray())
+	  precedingActivities = QString(QJsonDocument(precedingValue.toArray()).toJson(QJsonDocument::Compact));
+
+	theRecoveryTable->insertRow(row);
+	theRecoveryTable->setItem(row, 0, new QTableWidgetItem(key));
+	theRecoveryTable->setItem(row, 1, new QTableWidgetItem(duration));
+	theRecoveryTable->setItem(row, 2, new QTableWidgetItem(demand));
+	theRecoveryTable->setItem(row, 3, new QTableWidgetItem(precedingActivities));
+
 	row++;
       }
     }
   }
 
 
-  
   theComponentLibrary->addOrUpdateComponentTableEntry(theName->text(),
 						      theClass->currentText(),
-						      theDamageFunctionalRelation->currentText(),
-						      QString(""),QString(""));  
+						      joinedColumnNames(theSupplyTable, 0),
+						      joinedColumnNames(theOpDemandTable, 0),
+						      theRecoveryType->currentText());
   return true;
 }
 
 bool
 PyrecodesComponent::copyFiles(QString &dirName) {
+  Q_UNUSED(dirName);
   return true;
 }

--- a/RecoveryWidgets/pyrecodes/PyrecodesComponentLibrary.cpp
+++ b/RecoveryWidgets/pyrecodes/PyrecodesComponentLibrary.cpp
@@ -56,6 +56,15 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include "Utils/RelativePathResolver.h"
 #include "Utils/FileOperations.h"
 #include <PyrecodesComponent.h>
+#include <PyrecodesTemplates.h>
+
+// make a table's columns user-resizable and sized to fit their header labels
+static void setupColumns(QTableWidget *t) {
+  QHeaderView *h = t->horizontalHeader();
+  h->setSectionResizeMode(QHeaderView::Interactive);
+  h->setMinimumSectionSize(40);
+  t->resizeColumnsToContents();
+}
 
 PyrecodesComponentLibrary::PyrecodesComponentLibrary(QWidget *parent)
   :SimCenterWidget(parent)
@@ -65,9 +74,28 @@ PyrecodesComponentLibrary::PyrecodesComponentLibrary(QWidget *parent)
   // first a QLineEdit to Load and Save the info to a file
   //
   
-  QLineEdit   *theComponentLibraryFile = new QLineEdit();
+  theComponentLibraryFile = new QLineEdit();
+  theComponentLibraryFile->setToolTip("Path of the component library file (set when you Load or Save).");
   QPushButton *loadFileButton = new QPushButton("Load");
-  QPushButton *saveFileButton = new QPushButton("Save");  
+  loadFileButton->setToolTip("Load an existing component library JSON file.");
+  QPushButton *loadTemplateButton = new QPushButton("Load Template");
+  loadTemplateButton->setToolTip("Start from a built-in example with two components you can edit.");
+  QPushButton *saveFileButton = new QPushButton("Save");
+  saveFileButton->setToolTip("Save the component library to a JSON file (used by pyrecodes / R2DTool).");
+
+  //
+  // code for when user pushes the loadTemplateButton
+  //   - load the embedded starter component-library template
+  //
+  connect(loadTemplateButton, &QPushButton::clicked, this, [=]() {
+    QJsonDocument doc = QJsonDocument::fromJson(PyrecodesTemplates::componentLibrary().toUtf8());
+    QJsonObject jsonObj = doc.object();
+    this->clear();
+    if (this->inputFromJSON(jsonObj))
+      theComponentLibraryFile->setText("<template>");
+    else
+      this->errorMessage("Could not load component library template");
+  });
 
   //
   // code for when user pushes the loadFileButton
@@ -172,16 +200,22 @@ PyrecodesComponentLibrary::PyrecodesComponentLibrary(QWidget *parent)
   
   
   // addConstant PushButton
-  QPushButton *addComponentButton = new QPushButton("Add Component");  
+  QPushButton *addComponentButton = new QPushButton("Add Component");
+  addComponentButton->setToolTip("Open a dialog to define a new component (asset type).");
 
   QStringList headingsComponent; headingsComponent << "Name" << "Class" << "Supply" << "Demand" << "Recovery Model";
   theComponentsTable = new QTableWidget();
   theComponentsTable->setColumnCount(5);
   theComponentsTable->setHorizontalHeaderLabels(headingsComponent);
-  theComponentsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  // columns are user-resizable; they fit their headers/content initially
+  setupColumns(theComponentsTable);
   theComponentsTable->verticalHeader()->setVisible(false);
   theComponentsTable->setShowGrid(true);
-  theComponentsTable->setStyleSheet("QTableWidget::item { border: 1px solid black; }");  
+  theComponentsTable->setAlternatingRowColors(true);
+  theComponentsTable->setToolTip("Components defined so far. Click a row to Edit or Delete it.\n"
+				 "Supply/Demand columns list the resources each provides/consumes.");
+  if (theComponentsTable->horizontalHeaderItem(2)) theComponentsTable->horizontalHeaderItem(2)->setToolTip("Resources this component supplies");
+  if (theComponentsTable->horizontalHeaderItem(3)) theComponentsTable->horizontalHeaderItem(3)->setToolTip("Resources this component consumes (operation demand)");
   
   connect(addComponentButton, &QPushButton::clicked, this, [=]() {
     this->addComponent();
@@ -191,18 +225,28 @@ PyrecodesComponentLibrary::PyrecodesComponentLibrary(QWidget *parent)
   connect(theComponentsTable, SIGNAL(cellPressed(int,int)),this,SLOT(bringUpJobActionMenu(int,int)));  
   
   QGridLayout *layout = new QGridLayout(this);
-  layout->addWidget(new QLabel("Component Library File:"),0,0);
-  layout->addWidget(theComponentLibraryFile,0,1);
-  layout->addWidget(loadFileButton,0,2);
-  layout->addWidget(saveFileButton,0,3);
+
+  QLabel *intro = new QLabel(
+      "The Component Library lists every component (asset type) in your region and how each "
+      "supplies/consumes resources and recovers. Click \"Load Template\" to start from an example, "
+      "\"Add Component\" to define one, then \"Save\". Hover fields for help.");
+  intro->setWordWrap(true);
+  intro->setStyleSheet("color: #555; font-style: italic;");
+  layout->addWidget(intro, 0, 0, 1, 5);
+
+  layout->addWidget(new QLabel("Component Library File:"),1,0);
+  layout->addWidget(theComponentLibraryFile,1,1);
+  layout->addWidget(loadFileButton,1,2);
+  layout->addWidget(loadTemplateButton,1,3);
+  layout->addWidget(saveFileButton,1,4);
   layout->setColumnStretch(1,1);
 
   QGroupBox *theGroupBox = new QGroupBox("Component Library");
   QGridLayout *groupLayout = new QGridLayout(theGroupBox);
   groupLayout->addWidget(addComponentButton, 0,0, 1, 2);
   groupLayout->addWidget(theComponentsTable, 1, 0, 1, 5);
-  
-  layout->addWidget(theGroupBox,1,0,1,4);  
+
+  layout->addWidget(theGroupBox,2,0,1,5);
 }
 
 
@@ -211,6 +255,11 @@ PyrecodesComponentLibrary::~PyrecodesComponentLibrary()
 
 }
 
+
+QString
+PyrecodesComponentLibrary::getFileName() {
+  return theComponentLibraryFile->text();
+}
 
 void
 PyrecodesComponentLibrary::addComponent() {
@@ -242,6 +291,7 @@ PyrecodesComponentLibrary::inputFromJSON(QJsonObject &jsonObject)
 {
   theComponents.clear();
   theComponentsTable->clearContents();
+  theComponentsTable->setRowCount(0);
 
   for (const QString &key : jsonObject.keys()) {
 
@@ -297,8 +347,11 @@ PyrecodesComponentLibrary::addOrUpdateComponentTableEntry(QString name, QString 
   theComponentsTable->setItem(row, 0, newName);
   theComponentsTable->setItem(row, 1, newClass);
   theComponentsTable->setItem(row, 2, newSupply);
-  theComponentsTable->setItem(row, 2, newDemand);
-  theComponentsTable->setItem(row, 2, newRecovery);        
+  theComponentsTable->setItem(row, 3, newDemand);
+  theComponentsTable->setItem(row, 4, newRecovery);
+
+  // size columns to the new content (names etc.); user can still drag them
+  theComponentsTable->resizeColumnsToContents();
 }
 
 void

--- a/RecoveryWidgets/pyrecodes/PyrecodesComponentLibrary.h
+++ b/RecoveryWidgets/pyrecodes/PyrecodesComponentLibrary.h
@@ -75,6 +75,9 @@ public:
 
   void addOrUpdateComponentTableEntry(QString name, QString classT, QString supply, QString demand, QString recoveryModel);
 
+  //! current component library file path shown in the file field (may be empty or "<template>")
+  QString getFileName();
+
 public slots:
   void bringUpJobActionMenu(int row, int col);
   void deleteComponent();

--- a/RecoveryWidgets/pyrecodes/PyrecodesLocality.cpp
+++ b/RecoveryWidgets/pyrecodes/PyrecodesLocality.cpp
@@ -2,7 +2,7 @@
 Copyright (c) 2016-2023, The Regents of the University of California (Regents).
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
@@ -11,151 +11,219 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
-THIS SSensorsTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES Sensors MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPBodiesE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT Sensors SUBSTITUTE GOODS OR SERVICES;
-LBodiesS Sensors USE, DATA, OR PRSensorsITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY Sensors LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT Sensors THE USE Sensors THIS
-SSensorsTWARE, EVEN IF ADVISED Sensors THE PBodiesSIBILITY Sensors SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of the FreeBSD Project.
-
-REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
-THE IMPLIED WARRANTIES Sensors MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPBodiesE.
-THE SSensorsTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS 
-PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, 
-UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
+THE SOFTWARE IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 *************************************************************************** */
 
 
 #include <PyrecodesLocality.h>
+#include <PyrecodesOptions.h>
 #include <QGridLayout>
 #include <QLabel>
 #include <QGroupBox>
 #include <PyrecodesSystemConfig.h>
 
-
-#include <SC_CheckBox.h>
 #include <SC_FileEdit.h>
-#include <SC_StringLineEdit.h>
+#include <SC_ComboBox.h>
 
 #include <QLineEdit>
-
+#include <QPlainTextEdit>
 #include <QDebug>
-#include <QComboBox>
-#include <QListWidget>
-#include <QVBoxLayout>
 #include <QPushButton>
 #include <QWidget>
+#include <QDialog>
+#include <QStackedWidget>
+#include <QComboBox>
 #include <QJsonObject>
+#include <QJsonValue>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonParseError>
+
+// A starter template for the Components section. Uses R2D subsystem creators
+// since the main use case is running pyrecodes from R2DTool (the creator reads
+// the R2D exposure/damage JSON). The user edits this to match their region.
+static const char *kComponentsTemplate =
+"{\n"
+"  \"Infrastructure\": [\n"
+"    {\n"
+"      \"TransportationSystem\": {\n"
+"        \"CreatorClassName\": \"R2DSubsystemCreator\",\n"
+"        \"CreatorFileName\": \"r2d_subsystem_creator\",\n"
+"        \"Parameters\": {\n"
+"          \"Resource\": [\"TransportationService\"],\n"
+"          \"R2DJSONFile_Info\": \"{folder}/Exposure.json\",\n"
+"          \"SubsystemNameInR2DJSON\": \"TransportationNetwork\",\n"
+"          \"AssetTypes\": [\"Bridge\", \"Roadway\", \"Tunnel\"]\n"
+"        }\n"
+"      }\n"
+"    }\n"
+"  ],\n"
+"  \"BuildingStock\": [\n"
+"    {\n"
+"      \"Buildings\": {\n"
+"        \"CreatorClassName\": \"R2DSubsystemCreator\",\n"
+"        \"CreatorFileName\": \"r2d_subsystem_creator\",\n"
+"        \"Parameters\": {\n"
+"          \"Resource\": [\"Shelter\", \"FunctionalHousing\"],\n"
+"          \"R2DJSONFile_Info\": \"{folder}/Exposure.json\",\n"
+"          \"SubsystemNameInR2DJSON\": \"Buildings\",\n"
+"          \"AssetTypes\": [\"Buildings\"]\n"
+"        }\n"
+"      }\n"
+"    }\n"
+"  ],\n"
+"  \"RecoveryResourceSuppliers\": []\n"
+"}\n";
 
 PyrecodesLocality::PyrecodesLocality(PyrecodesSystemConfig *theSC, QString name, QWidget *parent)
   :SimCenterWidget(parent), theSystemConfig(theSC)
 {
   theName = new QLineEdit();
   theName->setText(name);
-  
-  coordinateFile = new SC_FileEdit("coordinateFile");
-  boundingBox = new QLineEdit();
-  buildingsCB = new SC_CheckBox("buildings");
-  infrastructureCB = new SC_CheckBox("infrastructure");
-  resourceSupplierCB = new SC_CheckBox("resourceSupplier");
-  QPushButton *doneButton = new QPushButton("Done");
+  theName->setToolTip("Locality name, e.g. \"Locality 1\". Referenced by distribution priorities\n"
+		      "and links between localities in the System Configuration.");
 
   //
-  // create a group box for the coordinates and another for the components
+  // Coordinates: edited in their own pop-up window. The main window shows a
+  // read-only summary and a button that opens the coordinates window. The
+  // window uses a stacked widget so only the fields for the chosen type show.
   //
-    
+
+  QStringList coordTypes; coordTypes << "Centroid" << "GeoJSON" << "BoundingBox";
+  coordType = new SC_ComboBox("coordType", coordTypes);
+  coordType->setToolTip("How the locality's location is given:\n"
+			"  Centroid    - a single point (X, Y)\n"
+			"  GeoJSON     - a polygon read from a .geojson file (typical for R2D regions)\n"
+			"  BoundingBox - a rectangle [xmin, ymin, xmax, ymax]");
+
+  centroidX = new QLineEdit();   centroidX->setPlaceholderText("X");
+  centroidX->setToolTip("Centroid X coordinate (longitude or projected X).");
+  centroidY = new QLineEdit();   centroidY->setPlaceholderText("Y");
+  centroidY->setToolTip("Centroid Y coordinate (latitude or projected Y).");
+  geoJSONFile = new SC_FileEdit("geoJSONFile");
+  geoJSONFile->setToolTip("Path to a .geojson file with the locality polygon.");
+  boundingBox = new QLineEdit(); boundingBox->setPlaceholderText("[xmin, ymin, xmax, ymax]");
+  boundingBox->setToolTip("Rectangle as a JSON array: [xmin, ymin, xmax, ymax].");
+
+  // one page of fields per coordinate type
+  coordStack = new QStackedWidget();
+
+  QWidget *centroidPage = new QWidget();
+  QGridLayout *centroidLayout = new QGridLayout(centroidPage);
+  centroidLayout->addWidget(new QLabel("X:"), 0, 0);
+  centroidLayout->addWidget(centroidX, 0, 1);
+  centroidLayout->addWidget(new QLabel("Y:"), 1, 0);
+  centroidLayout->addWidget(centroidY, 1, 1);
+  centroidLayout->setRowStretch(2, 1);
+
+  QWidget *geoPage = new QWidget();
+  QGridLayout *geoLayout = new QGridLayout(geoPage);
+  geoLayout->addWidget(new QLabel("GeoJSON file:"), 0, 0);
+  geoLayout->addWidget(geoJSONFile, 0, 1);
+  geoLayout->setRowStretch(1, 1);
+
+  QWidget *bboxPage = new QWidget();
+  QGridLayout *bboxLayout = new QGridLayout(bboxPage);
+  bboxLayout->addWidget(new QLabel("Bounding Box:"), 0, 0);
+  bboxLayout->addWidget(boundingBox, 0, 1);
+  bboxLayout->setRowStretch(1, 1);
+
+  coordStack->addWidget(centroidPage);   // index 0 -> Centroid
+  coordStack->addWidget(geoPage);        // index 1 -> GeoJSON
+  coordStack->addWidget(bboxPage);       // index 2 -> BoundingBox
+  connect(coordType, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	  coordStack, &QStackedWidget::setCurrentIndex);
+
+  // the dedicated coordinates window
+  coordDialog = new QDialog(this);
+  coordDialog->setWindowTitle("Define Coordinates");
+  coordDialog->setMinimumWidth(420);
+  QGridLayout *dlgLayout = new QGridLayout(coordDialog);
+  QLabel *dlgIntro = new QLabel("Choose how this locality's location is specified, then fill in the fields.");
+  dlgIntro->setWordWrap(true);
+  dlgIntro->setStyleSheet("color: #555; font-style: italic;");
+  dlgLayout->addWidget(dlgIntro, 0, 0, 1, 2);
+  dlgLayout->addWidget(new QLabel("Type:"), 1, 0);
+  dlgLayout->addWidget(coordType, 1, 1);
+  dlgLayout->addWidget(coordStack, 2, 0, 1, 2);
+  QPushButton *coordDoneButton = new QPushButton("Done");
+  connect(coordDoneButton, &QPushButton::clicked, coordDialog, &QDialog::accept);
+  dlgLayout->addWidget(coordDoneButton, 3, 1);
+
+  // main-window summary + button to open the coordinates window
   QGroupBox *coordinates = new QGroupBox("Coordinates");
   QGridLayout *coordinatesLayout = new QGridLayout(coordinates);
-  coordinatesLayout->addWidget(new QLabel("GeoJSON file:"),0,0);  
-  coordinatesLayout->addWidget(coordinateFile,0,1);  
-  coordinatesLayout->addWidget(new QLabel("Bounding Box:"),1,0);
-  coordinatesLayout->addWidget(boundingBox,1,1);    
+  coordSummary = new QLineEdit();
+  coordSummary->setReadOnly(true);
+  coordSummary->setPlaceholderText("No coordinates set - click \"Define Coordinates…\"");
+  QPushButton *editCoordButton = new QPushButton("Define Coordinates…");
+  editCoordButton->setToolTip("Open the coordinates window to set this locality's location.");
+  connect(editCoordButton, &QPushButton::clicked, this, [=]() {
+    coordStack->setCurrentIndex(coordType->currentIndex());
+    coordDialog->exec();
+    coordSummary->setText(this->coordinateSummary());
+  });
+  coordinatesLayout->addWidget(coordSummary, 0, 0);
+  coordinatesLayout->addWidget(editCoordButton, 0, 1);
+  coordinatesLayout->setColumnStretch(0, 1);
+
+  //
+  // Components group: JSON editor (Infrastructure / BuildingStock /
+  // RecoveryResourceSuppliers, each a list of subsystem creators)
+  //
 
   QGroupBox *components = new QGroupBox("Components");
   QGridLayout *componentsLayout = new QGridLayout(components);
-  componentsLayout->addWidget(buildingsCB, 0, 0);
-  componentsLayout->addWidget(new QLabel("Buildings"), 0,1);
-  componentsLayout->addWidget(infrastructureCB, 0, 2);  
-  componentsLayout->addWidget(new QLabel("Infrastructure"), 0,3);
+  componentsEdit = new QPlainTextEdit();
+  componentsEdit->setPlainText(kComponentsTemplate);
+  componentsEdit->setToolTip(
+      "Components in this locality, grouped under Infrastructure / BuildingStock /\n"
+      "RecoveryResourceSuppliers. Each entry names a subsystem and a creator:\n"
+      "  JSONSubsystemCreator - list components inline via \"ComponentsInLocality\"\n"
+      "  R2DSubsystemCreator  - build them from the R2D exposure file (R2DJSONFile_Info,\n"
+      "                         SubsystemNameInR2DJSON, AssetTypes).\n"
+      "Use \"Insert R2D Template\" for a starting point. Component names must exist in the Component Library.");
 
-  /* do with a list widget instead .. keeping around just in case
-  waterCB = new SC_CheckBox("water");
-  transportationCB = new SC_CheckBox("transportation");
-  componentsLayout->addWidget(waterCB, 1, 2);  
-  componentsLayout->addWidget(new QLabel("Water"), 1,3);
-  componentsLayout->addWidget(transportationCB, 2, 2);  
-  componentsLayout->addWidget(new QLabel("Transportation"), 2,3);  
-  */
-  
-  infrastructureList = new QListWidget();  
-  infrastructureList->addItem("Water");
-  infrastructureList->addItem("Transportation");
-  
-  for (int i = 0; i < infrastructureList->count(); ++i) {
-    QListWidgetItem *item = infrastructureList->item(i);
-    item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-    item->setCheckState(Qt::Unchecked);
-  }
-
-  componentsLayout->addWidget(infrastructureList, 1,3);  
-  componentsLayout->addWidget(resourceSupplierCB, 0, 4);    
-  componentsLayout->addWidget(new QLabel("Recovery Resource Supplier"),0,5);
-  componentsLayout->setColumnStretch(1,1);
-  componentsLayout->setColumnStretch(3,1);
-  componentsLayout->setColumnStretch(5,1);    
-    
-  //
-  // connections
-  //
-  
-  connect(infrastructureList, &QListWidget::itemChanged, this, [this]() {
-    QStringList selected;
-    for (int i = 0; i < infrastructureList->count(); ++i) {
-      QListWidgetItem *item = infrastructureList->item(i);
-      if (item->checkState() == Qt::Checked) {
-	selected << item->text();
-      }
-    }
+  QPushButton *insertTemplateButton = new QPushButton("Insert R2D Template");
+  insertTemplateButton->setToolTip("Replace the editor contents with a ready-to-edit R2D components block.");
+  connect(insertTemplateButton, &QPushButton::clicked, this, [=]() {
+    componentsEdit->setPlainText(kComponentsTemplate);
   });
+  QLabel *help = new QLabel(
+      "Each entry under Infrastructure / BuildingStock / RecoveryResourceSuppliers "
+      "is a subsystem created by one of: " + PyrecodesOptions::subsystemCreatorClasses().join(", ") + ".");
+  help->setWordWrap(true);
 
+  componentsLayout->addWidget(insertTemplateButton, 0, 0);
+  componentsLayout->addWidget(help, 1, 0);
+  componentsLayout->addWidget(componentsEdit, 2, 0);
+
+  //
+  // done button
+  //
+
+  QPushButton *doneButton = new QPushButton("Done");
   connect(doneButton, &QPushButton::clicked, this, [=]() {
-
-    // TO_DO: if file specified, open file and add geometry info 
-    QString coordinates = boundingBox->text();
     QStringList componentsSelected;
-    if (buildingsCB->checkState() == Qt::Checked)
-      componentsSelected << "Buildings";
-    if (infrastructureCB->checkState() == Qt::Checked)	{
-      componentsSelected << "Infrastructure";
-      for (int i = 0; i < infrastructureList->count(); ++i) {
-	QListWidgetItem *item = infrastructureList->item(i);
-	if (item->checkState() == Qt::Checked) {
-	  componentsSelected << item->text();
-	}
+    QJsonParseError pe;
+    QJsonDocument pd = QJsonDocument::fromJson(componentsEdit->toPlainText().toUtf8(), &pe);
+    if (pe.error == QJsonParseError::NoError && pd.isObject()) {
+      QJsonObject obj = pd.object();
+      for (const QString &group : obj.keys()) {
+	QJsonValue v = obj.value(group);
+	if (v.isArray() && !v.toArray().isEmpty())
+	  componentsSelected << group;
       }
-    if (resourceSupplierCB->checkState() == Qt::Checked)	{
-      componentsSelected << "RecoveryResourceSupplier";
-      // stuff here
-      }      
+    } else {
+      this->errorMessage("Components JSON is not valid - please fix before saving.");
     }
-    
-    // set table entries
-    theSystemConfig->addOrUpdateLocalityTableEntry(theName->text(),
-						   coordinates,
-						   componentsSelected);
 
-    // close the widget
+    theSystemConfig->addOrUpdateLocalityTableEntry(theName->text(),
+						   this->coordinateSummary(),
+						   componentsSelected);
     this->close();
-  });  
+  });
 
 
   //
@@ -163,16 +231,23 @@ PyrecodesLocality::PyrecodesLocality(PyrecodesSystemConfig *theSC, QString name,
   //
 
   QGridLayout *layout = new QGridLayout();
-  layout->addWidget(new QLabel("Name:"),0,0);
-  layout->addWidget(theName, 0,1);
 
-  layout->addWidget(coordinates, 1, 0, 1, 4);
-  layout->addWidget(components, 2, 0,  1, 4);
-  layout->addWidget(doneButton, 3, 1, 1, 2);
+  QLabel *intro = new QLabel(
+      "Define one locality: give it a name, set its coordinates, and list the components it "
+      "contains. Hover any field for help. Click Done when finished.");
+  intro->setWordWrap(true);
+  intro->setStyleSheet("color: #555; font-style: italic;");
+  layout->addWidget(intro, 0, 0, 1, 4);
 
-  layout->setRowStretch(4,1);
-  
-  
+  layout->addWidget(new QLabel("Name:"),1,0);
+  layout->addWidget(theName, 1,1);
+
+  layout->addWidget(coordinates, 2, 0, 1, 4);
+  layout->addWidget(components, 3, 0,  1, 4);
+  layout->addWidget(doneButton, 4, 1, 1, 2);
+
+  layout->setRowStretch(3,1);
+
   this->setLayout(layout);
 }
 
@@ -187,88 +262,124 @@ void PyrecodesLocality::clear(void)
 
 }
 
+QString
+PyrecodesLocality::coordinateSummary()
+{
+  QString type = coordType->currentText();
+  if (type == "Centroid")
+    return QString("Centroid (%1, %2)").arg(centroidX->text(), centroidY->text());
+  else if (type == "GeoJSON")
+    return QString("GeoJSON: %1").arg(geoJSONFile->getFilename());
+  else
+    return QString("BoundingBox %1").arg(boundingBox->text());
+}
+
 bool
 PyrecodesLocality::outputToJSON(QJsonObject &jsonObject)
 {
 
   QJsonObject obj;
-  
-  QJsonObject coordObj;    
 
-  obj["Coordinates"]=coordObj;  
+  //
+  // Coordinates
+  //
 
-  QJsonObject componentsObj;
+  QJsonObject coordObj;
+  QString type = coordType->currentText();
+  if (type == "Centroid") {
+    QJsonObject centroid;
+    bool okX, okY;
+    centroid["X"] = centroidX->text().toDouble(&okX);
+    centroid["Y"] = centroidY->text().toDouble(&okY);
+    coordObj["Centroid"] = centroid;
+  } else if (type == "GeoJSON") {
+    QJsonObject geo;
+    geo["Filename"] = geoJSONFile->getFilename();
+    coordObj["GeoJSON"] = geo;
+  } else if (type == "BoundingBox") {
+    QJsonParseError pe;
+    QJsonDocument pd = QJsonDocument::fromJson(boundingBox->text().toUtf8(), &pe);
+    if (pe.error == QJsonParseError::NoError && pd.isArray())
+      coordObj["BoundingBox"] = pd.array();
+    else
+      coordObj["BoundingBox"] = boundingBox->text();
+  }
+  obj["Coordinates"] = coordObj;
 
-  QJsonObject rrsObj;
-  
-  QJsonObject infrastructureObj;
-  QJsonObject buildingStockObj;
+  //
+  // Components (parse the JSON editor)
+  //
 
+  QJsonParseError pe;
+  QJsonDocument pd = QJsonDocument::fromJson(componentsEdit->toPlainText().toUtf8(), &pe);
+  if (pe.error == QJsonParseError::NoError && pd.isObject())
+    obj["Components"] = pd.object();
+  else
+    obj["Components"] = QJsonObject();
 
-  componentsObj["Infrastructure"] = infrastructureObj;    
-  componentsObj["BuildingStock"] = buildingStockObj;  
-  componentsObj["RecoveryResourceSuppliers"] = rrsObj;
-  obj["Components"]=componentsObj;
-
-  
   jsonObject[theName->text()] = obj;
-  
+
   return true;
 }
 
 bool
 PyrecodesLocality::inputFromJSON(QJsonObject &jsonObject)
 {
-  
-  QString coordinates;
+
   QStringList componentsSelected;
 
-  QJsonValue coordsValue = jsonObject["Coordinates"];
-  
-  QJsonValue componentsValue = jsonObject["Components"];
-  if (!componentsValue.isNull() && componentsValue.isObject()) {
-    QJsonObject componentsObj = componentsValue.toObject();
-    QJsonValue buildingsValue = componentsObj["BuildingStock"];    
-    QJsonValue infrastructureValue = componentsObj["Infrastructure"];
-    QJsonValue resourcesValue = componentsObj["RecoveryResourceSuppliers"];    
+  //
+  // Coordinates
+  //
 
-    if (!buildingsValue.isNull()) {
-      componentsSelected << "Buildings";
-      buildingsCB->setCheckState(Qt::Checked);
+  QJsonValue coordsValue = jsonObject["Coordinates"];
+  if (coordsValue.isObject()) {
+    QJsonObject coordObj = coordsValue.toObject();
+    if (coordObj.contains("Centroid") && coordObj["Centroid"].isObject()) {
+      coordType->setCurrentText("Centroid");
+      QJsonObject c = coordObj["Centroid"].toObject();
+      centroidX->setText(QString::number(c["X"].toDouble()));
+      centroidY->setText(QString::number(c["Y"].toDouble()));
+    } else if (coordObj.contains("GeoJSON") && coordObj["GeoJSON"].isObject()) {
+      coordType->setCurrentText("GeoJSON");
+      QJsonObject g = coordObj["GeoJSON"].toObject();
+      QString fn = g.contains("Filename") ? g["Filename"].toString() : g["FileName"].toString();
+      geoJSONFile->setFilename(fn);
+    } else if (coordObj.contains("BoundingBox")) {
+      coordType->setCurrentText("BoundingBox");
+      QJsonValue bb = coordObj["BoundingBox"];
+      if (bb.isArray())
+	boundingBox->setText(QString(QJsonDocument(bb.toArray()).toJson(QJsonDocument::Compact)));
+      else
+	boundingBox->setText(bb.toString());
     }
-    
-    if (!infrastructureValue.isNull()) {
-      componentsSelected << "Infrastructure";
-      infrastructureCB->setCheckState(Qt::Checked);
-      if (infrastructureValue.isObject()) {
-	QJsonObject infrastructureObj = infrastructureValue.toObject();
-	if (! infrastructureObj["TransportationSystem"].isNull()) {
-	  componentsSelected << "TransportationSystem";
-	  QListWidgetItem *item = infrastructureList->item(0);
-	  item->setCheckState(Qt::Checked);
-	}
-	if (! infrastructureObj["WaterSupplySystemSystem"].isNull()) {
-	  componentsSelected << "WaterSupplySystem";
-	  QListWidgetItem *item = infrastructureList->item(1);
-	  item->setCheckState(Qt::Checked);
-	}
-      }
-    }
-    
-    if (!resourcesValue.isNull()) {
-      componentsSelected << "RecoveryResourceSuppliers";
-      resourceSupplierCB->setCheckState(Qt::Checked);
-    }
-    
   }
-  
+  coordStack->setCurrentIndex(coordType->currentIndex());
+  coordSummary->setText(coordinateSummary());
+
+  //
+  // Components
+  //
+
+  QJsonValue componentsValue = jsonObject["Components"];
+  if (componentsValue.isObject()) {
+    QJsonObject componentsObj = componentsValue.toObject();
+    componentsEdit->setPlainText(QString(QJsonDocument(componentsObj).toJson(QJsonDocument::Indented)));
+    for (const QString &group : componentsObj.keys()) {
+      QJsonValue v = componentsObj.value(group);
+      if (v.isArray() && !v.toArray().isEmpty())
+	componentsSelected << group;
+    }
+  }
+
   theSystemConfig->addOrUpdateLocalityTableEntry(theName->text(),
-						 coordinates,
-						 componentsSelected);  
+						 coordinateSummary(),
+						 componentsSelected);
   return true;
 }
 
 bool
 PyrecodesLocality::copyFiles(QString &dirName) {
+  Q_UNUSED(dirName);
   return true;
 }

--- a/RecoveryWidgets/pyrecodes/PyrecodesLocality.h
+++ b/RecoveryWidgets/pyrecodes/PyrecodesLocality.h
@@ -51,8 +51,10 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 class  SC_FileEdit;
 class  QLineEdit;
-class  SC_CheckBox;
-class  QListWidget;
+class  SC_ComboBox;
+class  QPlainTextEdit;
+class  QDialog;
+class  QStackedWidget;
 class PyrecodesSystemConfig;
 
 
@@ -67,25 +69,30 @@ public:
   bool inputFromJSON(QJsonObject &jsonObject);
   bool copyFiles(QString &dirName);
   void clear(void);
-  
+
+private:
+  //! one-line summary of the current coordinates (for the table / summary field)
+  QString coordinateSummary();
+
 signals:
 
 private:
 
   // name
   QLineEdit  *theName;
-  
-  // coordinates
-  SC_FileEdit        *coordinateFile;
-  QLineEdit  *boundingBox;
 
-  // components
-  SC_CheckBox *buildingsCB;
-  SC_CheckBox *infrastructureCB;  
-  //SC_CheckBox *waterCB;
-  //SC_CheckBox *transportationCB;
-  QListWidget *infrastructureList;
-  SC_CheckBox *resourceSupplierCB;
+  // coordinates - edited in their own pop-up window (coordDialog)
+  SC_ComboBox    *coordType;       // Centroid | GeoJSON | BoundingBox
+  QLineEdit      *centroidX;
+  QLineEdit      *centroidY;
+  SC_FileEdit    *geoJSONFile;
+  QLineEdit      *boundingBox;     // JSON array, e.g. [xmin, ymin, xmax, ymax]
+  QDialog        *coordDialog;     // the dedicated coordinates window
+  QStackedWidget *coordStack;      // shows only the fields for the chosen type
+  QLineEdit      *coordSummary;    // read-only summary shown in the main window
+
+  // components (Infrastructure / BuildingStock / RecoveryResourceSuppliers)
+  QPlainTextEdit *componentsEdit;
 
   PyrecodesSystemConfig *theSystemConfig;
 };

--- a/RecoveryWidgets/pyrecodes/PyrecodesOptions.h
+++ b/RecoveryWidgets/pyrecodes/PyrecodesOptions.h
@@ -1,0 +1,200 @@
+#ifndef PYRECODES_OPTIONS_H
+#define PYRECODES_OPTIONS_H
+
+/* *****************************************************************************
+Copyright (c) 2016-2023, The Regents of the University of California (Regents).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THE SOFTWARE IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+*************************************************************************** */
+
+// Single source of truth for the option lists used by the pyrecodes UI
+// drop-downs. Mirrors the classes registered in pyrecodes 0.3.0. Each
+// ClassName is paired with its FileName (the snake_case python module that
+// pyrecodes imports it from); the UI auto-fills FileName when the user picks a
+// ClassName, so the produced JSON matches what pyrecodes expects.
+
+#include <QStringList>
+#include <QMap>
+#include <QString>
+
+namespace PyrecodesOptions {
+
+// ---- Component classes (ComponentClass.ClassName) -------------------------
+inline QStringList componentClasses() {
+  return QStringList()
+    << "StandardiReCoDeSComponent"
+    << "BuildingWithEmergencyCalls"
+    << "InfrastructureInterface"
+    << "Bridge"
+    << "Roadway"
+    << "Tunnel"
+    << "R2DBuilding"
+    << "R2DBuildingWithHouseholds"
+    << "R2DTown"
+    << "R2DBridge"
+    << "R2DRoadway"
+    << "R2DTunnel"
+    << "R2DPipe"
+    << "R2DTransportationComponent";
+}
+
+// ---- Recovery model classes (RecoveryModel.ClassName) ---------------------
+inline QStringList recoveryModelClasses() {
+  return QStringList()
+    << "NoRecoveryActivityModel"
+    << "ComponentLevelRecoveryActivitiesModel"
+    << "InfrastructureInterfaceRecoveryModel";
+}
+
+// ---- Relation types -------------------------------------------------------
+// Used for Supply.FunctionalityToAmountRelation, Supply.UnmetDemandToAmountRelation,
+// OperationDemand.FunctionalityToAmountRelation and
+// RecoveryModel.DamageFunctionalityRelation.Type.
+inline QStringList relationTypes() {
+  return QStringList()
+    << "Constant"
+    << "Linear"
+    << "ReverseLinear"
+    << "Binary"
+    << "ReverseBinary"
+    << "MultipleStep";
+}
+
+// ---- Probability distributions (recovery activity Duration) ---------------
+inline QStringList probabilityDistributions() {
+  return QStringList()
+    << "Deterministic"
+    << "Lognormal";
+}
+
+// ---- Resource groups ------------------------------------------------------
+inline QStringList resourceGroups() {
+  return QStringList()
+    << "Utilities"
+    << "TransferService"
+    << "RecoveryResources"
+    << "BridgeService";
+}
+
+// ---- Resource distribution model classes ----------------------------------
+inline QStringList distributionModelClasses() {
+  return QStringList()
+    << "UtilityDistributionModel"
+    << "HousingDistributionModel"
+    << "TransferServiceDistributionModelPotentialPaths"
+    << "BridgeServiceDistributionModel"
+    << "REWETDistributionModel"
+    << "ResidualDemandTrafficDistributionModel";
+}
+
+// ---- Distribution priority classes ----------------------------------------
+inline QStringList distributionPriorityClasses() {
+  return QStringList()
+    << "ComponentBasedPriority"
+    << "ComponentTypePriority"
+    << "SupplierOnlyPriority"
+    << "RandomPriority"
+    << "RandomPriorityWithPrioritizedInterfaces";
+}
+
+// ---- Damage input classes -------------------------------------------------
+inline QStringList damageInputClasses() {
+  return QStringList()
+    << "R2DDamageInput"
+    << "ListDamageInput"
+    << "FileDamageInput";
+}
+
+// ---- Resilience calculator classes ----------------------------------------
+inline QStringList resilienceCalculatorClasses() {
+  return QStringList()
+    << "ReCoDeSCalculator"
+    << "NISTGoalsCalculator"
+    << "ComponentRecoveryTimeCalculator"
+    << "R2DComponentRecoveryTimeCalculator"
+    << "FullRecoveryTimeCalculator";
+}
+
+// ---- Subsystem creator classes --------------------------------------------
+inline QStringList subsystemCreatorClasses() {
+  return QStringList()
+    << "JSONSubsystemCreator"
+    << "R2DSubsystemCreator"
+    << "R2DSubsystemCreatorWithHouseholds"
+    << "RecoveryResourceSuppliersCreator"
+    << "Tier1InfrastructureCreator";
+}
+
+// ---- ClassName -> FileName (python module) map ----------------------------
+// Auto-fills the FileName field that pyrecodes 0.3.0 requires alongside each
+// ClassName. Returns an empty string for unknown classes (caller may leave the
+// FileName out / let the user type one).
+inline QString fileNameForClass(const QString &className) {
+  static const QMap<QString, QString> map = {
+    // component classes
+    {"StandardiReCoDeSComponent",        "standard_irecodes_component"},
+    {"BuildingWithEmergencyCalls",       "building_with_emergency_calls"},
+    {"InfrastructureInterface",          "infrastructure_interface"},
+    {"Bridge",                           "component"},
+    {"Roadway",                          "component"},
+    {"Tunnel",                           "component"},
+    {"R2DBuilding",                      "r2d_component"},
+    {"R2DBridge",                        "r2d_component"},
+    {"R2DRoadway",                       "r2d_component"},
+    {"R2DTunnel",                        "r2d_component"},
+    {"R2DPipe",                          "r2d_component"},
+    {"R2DTransportationComponent",       "r2d_component"},
+    {"R2DComponent",                     "r2d_component"},
+    {"R2DBuildingWithHouseholds",        "r2d_building_with_households"},
+    {"R2DTown",                          "r2d_building_with_households"},
+    // recovery models
+    {"NoRecoveryActivityModel",                  "no_recovery_activity_model"},
+    {"ComponentLevelRecoveryActivitiesModel",    "component_level_recovery_activities_model"},
+    {"InfrastructureInterfaceRecoveryModel",     "infrastructure_interface_recovery_model"},
+    // distribution models
+    {"UtilityDistributionModel",                       "utility_distribution_model"},
+    {"HousingDistributionModel",                       "housing_distribution_model"},
+    {"TransferServiceDistributionModelPotentialPaths", "transfer_service_distribution_model_potential_paths"},
+    {"BridgeServiceDistributionModel",                 "bridge_service_distribution_model"},
+    {"REWETDistributionModel",                         "rewet_distribution_model"},
+    {"ResidualDemandTrafficDistributionModel",         "residual_demand_traffic_distribution_model"},
+    // distribution priorities
+    {"ComponentBasedPriority",                   "component_based_priority"},
+    {"ComponentTypePriority",                    "component_type_priority"},
+    {"SupplierOnlyPriority",                     "supplier_only_priority"},
+    {"RandomPriority",                           "random_priority"},
+    {"RandomPriorityWithPrioritizedInterfaces",  "random_priority_with_prioritized_interfaces"},
+    // damage input
+    {"R2DDamageInput",                           "r2d_damage_input"},
+    {"ListDamageInput",                          "list_damage_input"},
+    {"FileDamageInput",                          "file_damage_input"},
+    // resilience calculators
+    {"ReCoDeSCalculator",                        "recodes_calculator"},
+    {"NISTGoalsCalculator",                      "nist_goals_calculator"},
+    {"ComponentRecoveryTimeCalculator",          "component_recovery_time_calculator"},
+    {"R2DComponentRecoveryTimeCalculator",       "r2d_component_recovery_time_calculator"},
+    {"FullRecoveryTimeCalculator",               "full_recovery_time_calculator"},
+    // subsystem creators
+    {"JSONSubsystemCreator",                     "json_subsystem_creator"},
+    {"R2DSubsystemCreator",                      "r2d_subsystem_creator"},
+    {"R2DSubsystemCreatorWithHouseholds",        "r2d_subsystem_creator"},
+    {"RecoveryResourceSuppliersCreator",         "recovery_resource_suppliers_creator"},
+    {"Tier1InfrastructureCreator",               "tier1_infrastructure_creator"},
+  };
+  return map.value(className, QString());
+}
+
+} // namespace PyrecodesOptions
+
+#endif // PYRECODES_OPTIONS_H

--- a/RecoveryWidgets/pyrecodes/PyrecodesSystemConfig.cpp
+++ b/RecoveryWidgets/pyrecodes/PyrecodesSystemConfig.cpp
@@ -36,6 +36,7 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 
 #include <PyrecodesSystemConfig.h>
+#include <PyrecodesOptions.h>
 #include <QGridLayout>
 #include <QPushButton>
 #include <QTableWidget>
@@ -44,20 +45,58 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <QTabWidget>
 #include <QLabel>
 #include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QComboBox>
 #include <QFileInfo>
 #include <QFile>
 #include <QJsonDocument>
+#include <QJsonParseError>
 #include <QFileDialog>
 #include <QJsonObject>
+#include <QJsonValue>
 #include <QJsonArray>
 #include <QMessageBox>
 #include <QGroupBox>
 
+#include <SC_ComboBox.h>
 
 #include "Utils/RelativePathResolver.h"
 #include "Utils/FileOperations.h"
 
 #include <PyrecodesLocality.h>
+#include <PyrecodesTemplates.h>
+
+// helpers for combo cell widgets in tables
+static QComboBox *makeCombo(const QStringList &items, bool allowEmpty = false) {
+  QComboBox *cb = new QComboBox();
+  if (allowEmpty)
+    cb->addItem("");
+  cb->addItems(items);
+  return cb;
+}
+static QString comboTextAt(QTableWidget *t, int row, int col) {
+  QComboBox *cb = qobject_cast<QComboBox *>(t->cellWidget(row, col));
+  return cb ? cb->currentText() : QString();
+}
+static void setComboAt(QTableWidget *t, int row, int col, const QString &value) {
+  QComboBox *cb = qobject_cast<QComboBox *>(t->cellWidget(row, col));
+  if (cb) {
+    int idx = cb->findText(value);
+    if (idx < 0 && !value.isEmpty()) { cb->addItem(value); idx = cb->findText(value); }
+    cb->setCurrentIndex(idx >= 0 ? idx : 0);
+  }
+}
+static void setHeaderTipSC(QTableWidget *t, int col, const QString &tip) {
+  if (QTableWidgetItem *h = t->horizontalHeaderItem(col))
+    h->setToolTip(tip);
+}
+// make a table's columns user-resizable and sized to fit their header labels
+static void setupColumns(QTableWidget *t) {
+  QHeaderView *h = t->horizontalHeader();
+  h->setSectionResizeMode(QHeaderView::Interactive);
+  h->setMinimumSectionSize(40);
+  t->resizeColumnsToContents();
+}
 
 PyrecodesSystemConfig::PyrecodesSystemConfig(QWidget *parent)
   :SimCenterWidget(parent)
@@ -66,9 +105,29 @@ PyrecodesSystemConfig::PyrecodesSystemConfig(QWidget *parent)
   // first a QLineEdit to Load and Save the info to a file
   //
   
-  QLineEdit   *theSystemFile = new QLineEdit();
+  theSystemFile = new QLineEdit();
+  theSystemFile->setToolTip("Path of the system configuration file (set when you Load or Save).");
   QPushButton *loadFileButton = new QPushButton("Load");
-  QPushButton *saveFileButton = new QPushButton("Save");  
+  loadFileButton->setToolTip("Load an existing system configuration JSON file.");
+  QPushButton *loadTemplateButton = new QPushButton("Load Template");
+  loadTemplateButton->setToolTip("Start from a built-in example covering every section (Constants, Localities,\n"
+				 "Resources, Damage Input, Resilience Calculators) that you can edit.");
+  QPushButton *saveFileButton = new QPushButton("Save");
+  saveFileButton->setToolTip("Save the system configuration to a JSON file (used by pyrecodes / R2DTool).");
+
+  //
+  // code for when user pushes the loadTemplateButton
+  //   - load the embedded starter system-configuration template
+  //
+  connect(loadTemplateButton, &QPushButton::clicked, this, [=]() {
+    QJsonDocument doc = QJsonDocument::fromJson(PyrecodesTemplates::systemConfiguration().toUtf8());
+    QJsonObject jsonObj = doc.object();
+    this->clear();
+    if (this->inputFromJSON(jsonObj))
+      theSystemFile->setText("<template>");
+    else
+      this->errorMessage("Could not load system configuration template");
+  });
 
   //
   // code for when user pushes the loadFileButton
@@ -183,17 +242,27 @@ PyrecodesSystemConfig::PyrecodesSystemConfig(QWidget *parent)
   QWidget *constantsWidget = new QWidget();
   QGridLayout *constantsLayout = new QGridLayout(constantsWidget);
 
+  QLabel *constantsIntro = new QLabel(
+      "Global simulation settings. Required: START_TIME_STEP (usually 0), MAX_TIME_STEP "
+      "(how long to simulate) and DISASTER_TIME_STEP (when the hazard hits, e.g. 1). "
+      "Value may be a number, a JSON list or a JSON object.");
+  constantsIntro->setWordWrap(true);
+  constantsIntro->setStyleSheet("color: #555; font-style: italic;");
+
   // addConstant PushButton
-  QPushButton *addConstantButton = new QPushButton("Add Constant");  
+  QPushButton *addConstantButton = new QPushButton("Add Constant");
+  addConstantButton->setToolTip("Add a global setting (name/value pair).");
 
   QStringList headingsConstant; headingsConstant << "Name" << "Value";
   theConstantsTable = new QTableWidget();
   theConstantsTable->setColumnCount(2);
   theConstantsTable->setHorizontalHeaderLabels(headingsConstant);
-  theConstantsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  setupColumns(theConstantsTable);
   theConstantsTable->verticalHeader()->setVisible(false);
   theConstantsTable->setShowGrid(true);
-  theConstantsTable->setStyleSheet("QTableWidget::item { border: 1px solid black; }");  
+  theConstantsTable->setAlternatingRowColors(true);
+  if (theConstantsTable->horizontalHeaderItem(0)) theConstantsTable->horizontalHeaderItem(0)->setToolTip("Constant name, e.g. MAX_TIME_STEP");
+  if (theConstantsTable->horizontalHeaderItem(1)) theConstantsTable->horizontalHeaderItem(1)->setToolTip("Number, or JSON list/object, e.g. 1000  or  [\"Shelter\",\"FunctionalHousing\"]");
       
   connect(addConstantButton, &QPushButton::clicked, this, [=]() {
     
@@ -207,8 +276,9 @@ PyrecodesSystemConfig::PyrecodesSystemConfig(QWidget *parent)
     
   });  
 
-  constantsLayout->addWidget(addConstantButton, 0,0);
-  constantsLayout->addWidget(theConstantsTable, 1, 0, 1, 4);  
+  constantsLayout->addWidget(constantsIntro, 0, 0, 1, 4);
+  constantsLayout->addWidget(addConstantButton, 1,0);
+  constantsLayout->addWidget(theConstantsTable, 2, 0, 1, 4);
 
   
   //
@@ -218,8 +288,15 @@ PyrecodesSystemConfig::PyrecodesSystemConfig(QWidget *parent)
   QWidget *localitiesWidget = new QWidget();
   QGridLayout *layoutLocalities = new QGridLayout(localitiesWidget);
 
+  QLabel *localitiesIntro = new QLabel(
+      "Localities are the geographic units of the region (a community, neighbourhood, or TAZ). "
+      "Each locality has coordinates and a set of components. Click \"Add Locality\" to define one.");
+  localitiesIntro->setWordWrap(true);
+  localitiesIntro->setStyleSheet("color: #555; font-style: italic;");
+
   // addLocality PushButton
   QPushButton *addLocalityButton = new QPushButton("Add Locality");
+  addLocalityButton->setToolTip("Open a dialog to define a locality: its coordinates and components.");
 
 
   connect(addLocalityButton, &QPushButton::clicked, this, [=]() {
@@ -227,18 +304,20 @@ PyrecodesSystemConfig::PyrecodesSystemConfig(QWidget *parent)
   });
 
   // locality table
-  
+
   QStringList headingsLocality; headingsLocality << "Locality" << "Coordinates" << "Components";
   theLocalityTable = new QTableWidget();
   theLocalityTable->setColumnCount(3);
   theLocalityTable->setHorizontalHeaderLabels(headingsLocality);
-  theLocalityTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+  setupColumns(theLocalityTable);
   theLocalityTable->verticalHeader()->setVisible(false);
   theLocalityTable->setShowGrid(true);
-  theLocalityTable->setStyleSheet("QTableWidget::item { border: 1px solid black; }");
-  
-  layoutLocalities->addWidget(addLocalityButton, 0,0);
-  layoutLocalities->addWidget(theLocalityTable, 1, 0, 1, 4);
+  theLocalityTable->setAlternatingRowColors(true);
+  theLocalityTable->setToolTip("Localities defined so far (name, coordinates summary, component groups present).");
+
+  layoutLocalities->addWidget(localitiesIntro, 0, 0, 1, 4);
+  layoutLocalities->addWidget(addLocalityButton, 1,0);
+  layoutLocalities->addWidget(theLocalityTable, 2, 0, 1, 4);
   
   //
   // resources tab
@@ -247,55 +326,159 @@ PyrecodesSystemConfig::PyrecodesSystemConfig(QWidget *parent)
   QWidget *resourcesWidget = new QWidget();
   QGridLayout *layoutResources = new QGridLayout(resourcesWidget);
   
-  QPushButton *addResourceButton = new QPushButton("Add Resourcse");
+  QLabel *resourcesIntro = new QLabel(
+      "Resources are what components exchange (e.g. ElectricPower, PotableWater, RepairCrew). "
+      "For each, choose a Group and a Distribution Model that decides how the resource is shared "
+      "across the region after the disaster. Names must match those used in the Component Library.");
+  resourcesIntro->setWordWrap(true);
+  resourcesIntro->setStyleSheet("color: #555; font-style: italic;");
 
-  QStringList headingsResources; headingsResources << "Name" << "Group" << "Distribution Model";
+  QPushButton *addResourceButton = new QPushButton("Add Resource");
+  addResourceButton->setToolTip("Add a resource and choose how it is distributed.");
+
+  QStringList headingsResources;
+  headingsResources << "Name" << "Group" << "Distribution Model" << "Distribution Model Parameters (JSON)";
   theResourcesTable = new QTableWidget();
-  theResourcesTable->setColumnCount(3);
+  theResourcesTable->setColumnCount(4);
   theResourcesTable->setHorizontalHeaderLabels(headingsResources);
-  theResourcesTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-  theResourcesTable->verticalHeader()->setVisible(false);  
+  setupColumns(theResourcesTable);
+  theResourcesTable->verticalHeader()->setVisible(false);
   theResourcesTable->setShowGrid(true);
-  theResourcesTable->setStyleSheet("QTableWidget::item { border: 1px solid black; }");
-  
+  theResourcesTable->setAlternatingRowColors(true);
+  setHeaderTipSC(theResourcesTable, 0, "Resource name, e.g. ElectricPower. Must match Supply/Demand in the Component Library.");
+  setHeaderTipSC(theResourcesTable, 1, "Resource group: Utilities (most), TransferService (transport links),\n"
+		"RecoveryResources (crews/money), BridgeService.");
+  setHeaderTipSC(theResourcesTable, 2, "How the resource is allocated when scarce:\n"
+		"  UtilityDistributionModel - network utilities (power, water, comms)\n"
+		"  HousingDistributionModel - shelter / functional housing\n"
+		"  TransferServiceDistributionModelPotentialPaths - transport over a path network.");
+  setHeaderTipSC(theResourcesTable, 3, "Model-specific settings as JSON, e.g. a DistributionPriority block.\n"
+		"Use {} if none. See an example via \"Load Template\".");
+
   connect(addResourceButton, &QPushButton::clicked, this, [=]() {
-    
-    // add a row and set values to empty strings
     int row = theResourcesTable->rowCount();
     theResourcesTable->insertRow(row);
-    for (int col = 0; col < 3; ++col) {
-      QTableWidgetItem *item = new QTableWidgetItem(""); // Empty cell
-      theResourcesTable->setItem(row, col, item);
-    }
-  });  
+    theResourcesTable->setItem(row, 0, new QTableWidgetItem(""));
+    theResourcesTable->setCellWidget(row, 1, makeCombo(PyrecodesOptions::resourceGroups()));
+    theResourcesTable->setCellWidget(row, 2, makeCombo(PyrecodesOptions::distributionModelClasses()));
+    theResourcesTable->setItem(row, 3, new QTableWidgetItem("{}"));
+  });
 
-  
-  layoutResources->addWidget(addResourceButton,0, 0);
-  layoutResources->addWidget(theResourcesTable, 1, 0, 1, 4);
+  layoutResources->addWidget(resourcesIntro, 0, 0, 1, 4);
+  layoutResources->addWidget(addResourceButton, 1, 0);
+  layoutResources->addWidget(theResourcesTable, 2, 0, 1, 4);
+
+  //
+  // damage input tab
+  //
+
+  QWidget *damageWidget = new QWidget();
+  QGridLayout *layoutDamage = new QGridLayout(damageWidget);
+
+  QLabel *damageIntro = new QLabel(
+      "Defines the initial damage applied to components at the disaster time step.\n"
+      "  R2DDamageInput  - reads an R2D damage results file (use this when running from R2DTool)\n"
+      "  ListDamageInput - damage given inline as a list of values, one per damaged component\n"
+      "  FileDamageInput - reads damage from a separate file.");
+  damageIntro->setWordWrap(true);
+  damageIntro->setStyleSheet("color: #555; font-style: italic;");
+
+  theDamageInputClass = new SC_ComboBox("damageInputClass", PyrecodesOptions::damageInputClasses());
+  theDamageInputClass->setToolTip("Source of the initial damage. The FileName field is filled in automatically.");
+  theDamageInputParams = new QPlainTextEdit();
+  theDamageInputParams->setToolTip(
+      "Parameters for the chosen class, as JSON.\n"
+      "  R2DDamageInput : {\"DamageFile\": \"{folder}/Damage.json\", \"DistributionModelDamage\": [\"PotableWater\"]}\n"
+      "  ListDamageInput: [0.4, 0.0, 0.4, ...]   (one damage value per component, in build order)");
+  theDamageInputParams->setPlaceholderText(
+      "Parameters as JSON, e.g.\n"
+      "{\n  \"DamageFile\": \"{folder}/Damage.json\",\n  \"DistributionModelDamage\": [\"PotableWater\"]\n}");
+  layoutDamage->addWidget(damageIntro, 0, 0, 1, 2);
+  layoutDamage->addWidget(new QLabel("Damage Input Class:"), 1, 0);
+  layoutDamage->addWidget(theDamageInputClass, 1, 1);
+  layoutDamage->addWidget(new QLabel("Parameters (JSON):"), 2, 0, Qt::AlignTop);
+  layoutDamage->addWidget(theDamageInputParams, 2, 1);
+  layoutDamage->setColumnStretch(1, 1);
+  layoutDamage->setRowStretch(2, 1);
+
+  //
+  // resilience calculator tab
+  //
+
+  QWidget *resilienceWidget = new QWidget();
+  QGridLayout *layoutResilience = new QGridLayout(resilienceWidget);
+
+  QLabel *resilienceIntro = new QLabel(
+      "Resilience calculators are the metrics computed during the simulation. You can add several. "
+      "  ReCoDeSCalculator - lack-of-resilience (unmet demand) for the listed resources\n"
+      "  NISTGoalsCalculator - time to reach target functionality levels\n"
+      "  R2DComponentRecoveryTimeCalculator - per-component recovery times (for R2DTool).");
+  resilienceIntro->setWordWrap(true);
+  resilienceIntro->setStyleSheet("color: #555; font-style: italic;");
+
+  QPushButton *addResilienceButton = new QPushButton("Add Resilience Calculator");
+  addResilienceButton->setToolTip("Add a resilience metric to compute during the simulation.");
+
+  QStringList headingsResilience;
+  headingsResilience << "Calculator Class" << "Parameters (JSON)";
+  theResilienceTable = new QTableWidget();
+  theResilienceTable->setColumnCount(2);
+  theResilienceTable->setHorizontalHeaderLabels(headingsResilience);
+  setupColumns(theResilienceTable);
+  theResilienceTable->verticalHeader()->setVisible(false);
+  theResilienceTable->setShowGrid(true);
+  theResilienceTable->setAlternatingRowColors(true);
+  setHeaderTipSC(theResilienceTable, 0, "Metric to compute. FileName is filled in automatically.");
+  setHeaderTipSC(theResilienceTable, 1, "Parameters as JSON, e.g.\n"
+		"  ReCoDeSCalculator : {\"Scope\": \"All\", \"Resources\": [\"ElectricPower\"]}\n"
+		"  NISTGoalsCalculator: [{\"Resource\": \"ElectricPower\", \"DesiredFunctionalityLevel\": 0.95, \"Scope\": \"All\"}]");
+
+  connect(addResilienceButton, &QPushButton::clicked, this, [=]() {
+    int row = theResilienceTable->rowCount();
+    theResilienceTable->insertRow(row);
+    theResilienceTable->setCellWidget(row, 0, makeCombo(PyrecodesOptions::resilienceCalculatorClasses()));
+    theResilienceTable->setItem(row, 1, new QTableWidgetItem("{\"Scope\": \"All\", \"Resources\": []}"));
+  });
+
+  layoutResilience->addWidget(resilienceIntro, 0, 0, 1, 4);
+  layoutResilience->addWidget(addResilienceButton, 1, 0);
+  layoutResilience->addWidget(theResilienceTable, 2, 0, 1, 4);
 
   //
   // add widgets to theTabbedWidget
   //
 
-  theTabbedWidget->addTab(constantsWidget,"Constants");    
-  theTabbedWidget->addTab(localitiesWidget,"Localities");  
+  theTabbedWidget->addTab(constantsWidget,"Constants");
+  theTabbedWidget->addTab(localitiesWidget,"Localities");
   theTabbedWidget->addTab(resourcesWidget,"Resources");
+  theTabbedWidget->addTab(damageWidget,"Damage Input");
+  theTabbedWidget->addTab(resilienceWidget,"Resilience Calculators");
 
   //
   // finally add tabbedWidget to a layout for this
   //
   
   QGridLayout *layout = new QGridLayout(this);
-  layout->addWidget(new QLabel("System Config File:"),0,0);
-  layout->addWidget(theSystemFile,0,1);
-  layout->addWidget(loadFileButton,0,2);
-  layout->addWidget(saveFileButton,0,3);
+
+  QLabel *intro = new QLabel(
+      "The System Configuration describes the region: its localities, the resources exchanged, "
+      "the initial damage, and the resilience metrics to compute. Fill in each tab below "
+      "(start with \"Load Template\"), then \"Save\". Hover any field or column header for help.");
+  intro->setWordWrap(true);
+  intro->setStyleSheet("color: #555; font-style: italic;");
+  layout->addWidget(intro, 0, 0, 1, 5);
+
+  layout->addWidget(new QLabel("System Config File:"),1,0);
+  layout->addWidget(theSystemFile,1,1);
+  layout->addWidget(loadFileButton,1,2);
+  layout->addWidget(loadTemplateButton,1,3);
+  layout->addWidget(saveFileButton,1,4);
   layout->setColumnStretch(1,1);
 
   QGroupBox *theGroupBox = new QGroupBox("System Configuration");
   QGridLayout *groupLayout = new QGridLayout(theGroupBox);
   groupLayout->addWidget(theTabbedWidget,0,0);
-  layout->addWidget(theGroupBox,1,0,1,4);
+  layout->addWidget(theGroupBox,2,0,1,5);
 }
 
 
@@ -304,6 +487,11 @@ PyrecodesSystemConfig::~PyrecodesSystemConfig()
 
 }
 
+
+QString
+PyrecodesSystemConfig::getFileName() {
+  return theSystemFile->text();
+}
 
 void
 PyrecodesSystemConfig::addLocality() {
@@ -366,28 +554,99 @@ PyrecodesSystemConfig::outputToJSON(QJsonObject &jsonObject)
   // read resourcses data & fill the table
   //
 
-  QJsonObject resourcesObject;  
-    
+  QJsonObject resourcesObject;
+
   for (int row = 0; row < theResourcesTable->rowCount(); row++) {
 
     QJsonObject obj;
     QTableWidgetItem *keyItem = theResourcesTable->item(row, 0);
-    QTableWidgetItem *groupItem = theResourcesTable->item(row, 1);
-    QTableWidgetItem *distributionItem = theResourcesTable->item(row, 2);
-      
+    if (keyItem == nullptr || keyItem->text().isEmpty())
+      continue;
+
     QString key = keyItem->text();
-    QString group = groupItem->text();
-    QString distributionClass = distributionItem->text();
-    
+    QString group = comboTextAt(theResourcesTable, row, 1);
+    QString distributionClass = comboTextAt(theResourcesTable, row, 2);
+    QTableWidgetItem *paramsItem = theResourcesTable->item(row, 3);
+
     QJsonObject distrObj;
     distrObj["ClassName"] = distributionClass;
-    obj["DistributionModel"] = distrObj;
-    obj["Group"]=group;
-    
-    resourcesObject[key] = obj;
+    QString distrFile = PyrecodesOptions::fileNameForClass(distributionClass);
+    if (!distrFile.isEmpty())
+      distrObj["FileName"] = distrFile;
 
+    // optional Parameters JSON object
+    if (paramsItem && !paramsItem->text().trimmed().isEmpty()) {
+      QJsonParseError pe;
+      QJsonDocument pd = QJsonDocument::fromJson(paramsItem->text().toUtf8(), &pe);
+      if (pe.error == QJsonParseError::NoError && pd.isObject())
+	distrObj["Parameters"] = pd.object();
+    }
+
+    obj["DistributionModel"] = distrObj;
+    obj["Group"] = group;
+
+    resourcesObject[key] = obj;
   }
   jsonObject["Resources"]=resourcesObject;
+
+  //
+  // DamageInput
+  //
+
+  QString damageClass = theDamageInputClass->currentText();
+  if (!damageClass.isEmpty()) {
+    QJsonObject damageObject;
+    damageObject["ClassName"] = damageClass;
+    QString damageFile = PyrecodesOptions::fileNameForClass(damageClass);
+    if (!damageFile.isEmpty())
+      damageObject["FileName"] = damageFile;
+
+    QString paramsText = theDamageInputParams->toPlainText().trimmed();
+    if (!paramsText.isEmpty()) {
+      QJsonParseError pe;
+      QJsonDocument pd = QJsonDocument::fromJson(paramsText.toUtf8(), &pe);
+      if (pe.error == QJsonParseError::NoError && pd.isObject())
+	damageObject["Parameters"] = pd.object();
+      else if (pe.error == QJsonParseError::NoError && pd.isArray())
+	damageObject["Parameters"] = pd.array();
+      else
+	// not a JSON object/array: keep as a plain string, e.g. a file path
+	// like "{folder}/example_2_damage_input.txt" (used by FileDamageInput)
+	damageObject["Parameters"] = paramsText;
+    }
+    jsonObject["DamageInput"] = damageObject;
+  }
+
+  //
+  // ResilienceCalculator (array)
+  //
+
+  QJsonArray resilienceArray;
+  for (int row = 0; row < theResilienceTable->rowCount(); row++) {
+    QString calcClass = comboTextAt(theResilienceTable, row, 0);
+    if (calcClass.isEmpty())
+      continue;
+    QJsonObject calcObj;
+    calcObj["ClassName"] = calcClass;
+    QString calcFile = PyrecodesOptions::fileNameForClass(calcClass);
+    if (!calcFile.isEmpty())
+      calcObj["FileName"] = calcFile;
+
+    QTableWidgetItem *paramsItem = theResilienceTable->item(row, 1);
+    if (paramsItem && !paramsItem->text().trimmed().isEmpty()) {
+      QJsonParseError pe;
+      QJsonDocument pd = QJsonDocument::fromJson(paramsItem->text().toUtf8(), &pe);
+      if (pe.error == QJsonParseError::NoError) {
+	if (pd.isObject())
+	  calcObj["Parameters"] = pd.object();
+	else if (pd.isArray())
+	  calcObj["Parameters"] = pd.array();
+      }
+    }
+    resilienceArray.append(calcObj);
+  }
+  if (!resilienceArray.isEmpty())
+    jsonObject["ResilienceCalculator"] = resilienceArray;
 
 
   QJsonObject contentObject;
@@ -458,9 +717,9 @@ PyrecodesSystemConfig::inputFromJSON(QJsonObject &jsonObject)
   numRow = 0;
   
   QJsonObject resourcesObject = jsonObject["Resources"].toObject();
-  theResourcesTable->clearContents();  
-  theResourcesTable->setRowCount(resourcesObject.size());
-  
+  theResourcesTable->clearContents();
+  theResourcesTable->setRowCount(0);
+
   for (const QString &key : resourcesObject.keys()) {
 
     QJsonValue value = resourcesObject.value(key);
@@ -468,7 +727,8 @@ PyrecodesSystemConfig::inputFromJSON(QJsonObject &jsonObject)
 
       QString groupStr;
       QString distributionStr;
-      
+      QString paramsStr;
+
       QJsonObject valueObj = value.toObject();
       QJsonValue groupValue = valueObj["Group"];
       if (!groupValue.isNull() && groupValue.isString())
@@ -479,20 +739,76 @@ PyrecodesSystemConfig::inputFromJSON(QJsonObject &jsonObject)
 	QJsonObject distributionObject = distributionValue.toObject();
 	if (!distributionObject["ClassName"].isNull())
 	  distributionStr = distributionObject["ClassName"].toString();
+	QJsonValue paramsValue = distributionObject["Parameters"];
+	if (paramsValue.isObject())
+	  paramsStr = QString(QJsonDocument(paramsValue.toObject()).toJson(QJsonDocument::Compact));
       }
-	
-      // set table items
+
+      theResourcesTable->insertRow(numRow);
       theResourcesTable->setItem(numRow, 0, new QTableWidgetItem(key));
-      theResourcesTable->setItem(numRow, 1, new QTableWidgetItem(groupStr));
-      theResourcesTable->setItem(numRow, 2, new QTableWidgetItem(distributionStr));
-      qDebug() << key << " " << groupStr << " " << distributionStr;
+      theResourcesTable->setCellWidget(numRow, 1, makeCombo(PyrecodesOptions::resourceGroups()));
+      theResourcesTable->setCellWidget(numRow, 2, makeCombo(PyrecodesOptions::distributionModelClasses()));
+      setComboAt(theResourcesTable, numRow, 1, groupStr);
+      setComboAt(theResourcesTable, numRow, 2, distributionStr);
+      theResourcesTable->setItem(numRow, 3, new QTableWidgetItem(paramsStr));
       numRow++;
-      
+
     } else {
-      
+
       // error Message
-      QString msg(QString("In Resourses section, item with key") + key + QString(" is not valid JSON"));
+      QString msg(QString("In Resources section, item with key") + key + QString(" is not valid JSON"));
       this->errorMessage(msg);
+    }
+  }
+
+  //
+  // read DamageInput
+  //
+
+  QJsonValue damageValue = jsonObject["DamageInput"];
+  theDamageInputParams->clear();
+  if (damageValue.isObject()) {
+    QJsonObject damageObj = damageValue.toObject();
+    QJsonValue classValue = damageObj["ClassName"];
+    if (classValue.isString()) {
+      int idx = theDamageInputClass->findText(classValue.toString());
+      if (idx >= 0) theDamageInputClass->setCurrentIndex(idx);
+    }
+    QJsonValue paramsValue = damageObj["Parameters"];
+    if (paramsValue.isObject())
+      theDamageInputParams->setPlainText(QString(QJsonDocument(paramsValue.toObject()).toJson(QJsonDocument::Indented)));
+    else if (paramsValue.isArray())
+      theDamageInputParams->setPlainText(QString(QJsonDocument(paramsValue.toArray()).toJson(QJsonDocument::Indented)));
+    else if (paramsValue.isString())
+      theDamageInputParams->setPlainText(paramsValue.toString());
+    else if (paramsValue.isDouble())
+      theDamageInputParams->setPlainText(QString::number(paramsValue.toDouble()));
+  }
+
+  //
+  // read ResilienceCalculator
+  //
+
+  theResilienceTable->clearContents();
+  theResilienceTable->setRowCount(0);
+  QJsonValue resilienceValue = jsonObject["ResilienceCalculator"];
+  if (resilienceValue.isArray()) {
+    QJsonArray arr = resilienceValue.toArray();
+    int row = 0;
+    for (const QJsonValue &cv : arr) {
+      if (!cv.isObject()) continue;
+      QJsonObject calcObj = cv.toObject();
+      theResilienceTable->insertRow(row);
+      theResilienceTable->setCellWidget(row, 0, makeCombo(PyrecodesOptions::resilienceCalculatorClasses()));
+      setComboAt(theResilienceTable, row, 0, calcObj["ClassName"].toString());
+      QJsonValue paramsValue = calcObj["Parameters"];
+      QString paramsStr;
+      if (paramsValue.isObject())
+	paramsStr = QString(QJsonDocument(paramsValue.toObject()).toJson(QJsonDocument::Compact));
+      else if (paramsValue.isArray())
+	paramsStr = QString(QJsonDocument(paramsValue.toArray()).toJson(QJsonDocument::Compact));
+      theResilienceTable->setItem(row, 1, new QTableWidgetItem(paramsStr));
+      row++;
     }
   }
 
@@ -504,9 +820,9 @@ PyrecodesSystemConfig::inputFromJSON(QJsonObject &jsonObject)
 
   numRow = 0;
   
-  QJsonObject localityObject = jsonObject["Content"].toObject();  
-  // theLocalityTable->setRowCount(localityObject.size());
+  QJsonObject localityObject = jsonObject["Content"].toObject();
   theLocalityTable->clearContents();
+  theLocalityTable->setRowCount(0);
   theLocalities.clear();
   
   for (const QString &key : localityObject.keys()) {

--- a/RecoveryWidgets/pyrecodes/PyrecodesSystemConfig.h
+++ b/RecoveryWidgets/pyrecodes/PyrecodesSystemConfig.h
@@ -54,6 +54,8 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 class QTableWidget;
 class PyrecodesLocality;
 class QLineEdit;
+class SC_ComboBox;
+class QPlainTextEdit;
 
 class PyrecodesSystemConfig : public SimCenterWidget
 {
@@ -73,16 +75,26 @@ public:
   void addLocality();
 
   void addOrUpdateLocalityTableEntry(QString, QString, QStringList);
+
+  //! current system configuration file path shown in the file field (may be empty or "<template>")
+  QString getFileName();
   
 signals:
 
 private:
 
   QLineEdit *theSystemFile;
-  QTableWidget *theConstantsTable;  
+  QTableWidget *theConstantsTable;
   QTableWidget *theLocalityTable;
-  QTableWidget *theResourcesTable;  
+  QTableWidget *theResourcesTable;
   QList<PyrecodesLocality *>theLocalities;
+
+  // DamageInput section
+  SC_ComboBox    *theDamageInputClass;
+  QPlainTextEdit *theDamageInputParams;
+
+  // ResilienceCalculator section
+  QTableWidget   *theResilienceTable;
 
 };
 

--- a/RecoveryWidgets/pyrecodes/PyrecodesTemplates.h
+++ b/RecoveryWidgets/pyrecodes/PyrecodesTemplates.h
@@ -1,0 +1,143 @@
+#ifndef PYRECODES_TEMPLATES_H
+#define PYRECODES_TEMPLATES_H
+
+/* *****************************************************************************
+Copyright (c) 2016-2023, The Regents of the University of California (Regents).
+All rights reserved. THE SOFTWARE IS PROVIDED "AS IS".
+*************************************************************************** */
+
+// Starter templates for the two files the pyrecodes UI builds. Embedded as
+// string literals (rather than read from disk) so the "Load Template" buttons
+// work regardless of the working directory and without any build-system change
+// when these widgets are compiled into R2DTool. The same content is mirrored in
+// pyrecodes_input_templates/template_*.json for users who want the files.
+//
+// The two templates form one coherent, minimal-but-complete, valid pyrecodes
+// 0.3.0 community: a supplier + a building in one locality, with every system
+// configuration section present (Constants, Content, DamageInput, Resources,
+// ResilienceCalculator). Users edit from here instead of starting blank.
+
+#include <QString>
+
+namespace PyrecodesTemplates {
+
+inline QString componentLibrary() {
+  return QString::fromUtf8(R"({
+    "ExampleSupplier": {
+        "ComponentClass": {
+            "FileName": "standard_irecodes_component",
+            "ClassName": "StandardiReCoDeSComponent"
+        },
+        "RecoveryModel": {
+            "FileName": "component_level_recovery_activities_model",
+            "ClassName": "ComponentLevelRecoveryActivitiesModel",
+            "Parameters": {
+                "Repair": {
+                    "Duration": { "Deterministic": { "Value": 10 } },
+                    "Demand": [],
+                    "PrecedingActivities": []
+                }
+            },
+            "DamageFunctionalityRelation": { "Type": "ReverseBinary" }
+        },
+        "Supply": {
+            "ElectricPower": {
+                "Amount": 10,
+                "FunctionalityToAmountRelation": "Linear",
+                "UnmetDemandToAmountRelation": "Binary"
+            }
+        }
+    },
+    "ExampleBuilding": {
+        "ComponentClass": {
+            "FileName": "standard_irecodes_component",
+            "ClassName": "StandardiReCoDeSComponent"
+        },
+        "RecoveryModel": {
+            "FileName": "component_level_recovery_activities_model",
+            "ClassName": "ComponentLevelRecoveryActivitiesModel",
+            "Parameters": {
+                "Repair": {
+                    "Duration": { "Lognormal": { "Median": 30, "Dispersion": 0.4 } },
+                    "Demand": [],
+                    "PrecedingActivities": []
+                }
+            },
+            "DamageFunctionalityRelation": { "Type": "ReverseBinary" }
+        },
+        "OperationDemand": {
+            "ElectricPower": {
+                "Amount": 1,
+                "FunctionalityToAmountRelation": "Linear"
+            }
+        }
+    }
+})");
+}
+
+inline QString systemConfiguration() {
+  return QString::fromUtf8(R"({
+    "Constants": {
+        "START_TIME_STEP": 0,
+        "MAX_TIME_STEP": 100,
+        "DISASTER_TIME_STEP": 1
+    },
+    "Content": {
+        "Locality 1": {
+            "Coordinates": { "Centroid": { "X": 0, "Y": 0 } },
+            "Components": {
+                "Infrastructure": [
+                    {
+                        "ElectricPowerSystem": {
+                            "CreatorClassName": "JSONSubsystemCreator",
+                            "CreatorFileName": "json_subsystem_creator",
+                            "Parameters": { "ComponentsInLocality": { "ExampleSupplier": 1 } }
+                        }
+                    }
+                ],
+                "BuildingStock": [
+                    {
+                        "Buildings": {
+                            "CreatorClassName": "JSONSubsystemCreator",
+                            "CreatorFileName": "json_subsystem_creator",
+                            "Parameters": { "ComponentsInLocality": { "ExampleBuilding": 1 } }
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "DamageInput": {
+        "FileName": "list_damage_input",
+        "ClassName": "ListDamageInput",
+        "Parameters": [ 0.5, 0.5 ]
+    },
+    "Resources": {
+        "ElectricPower": {
+            "Group": "Utilities",
+            "DistributionModel": {
+                "ClassName": "UtilityDistributionModel",
+                "FileName": "utility_distribution_model",
+                "Parameters": {
+                    "DistributionPriority": {
+                        "FileName": "component_based_priority",
+                        "ClassName": "ComponentBasedPriority",
+                        "Parameters": [ [ "ExampleSupplier", [ "Locality 1" ], "OperationDemand" ] ]
+                    }
+                }
+            }
+        }
+    },
+    "ResilienceCalculator": [
+        {
+            "FileName": "recodes_calculator",
+            "ClassName": "ReCoDeSCalculator",
+            "Parameters": { "Scope": "All", "Resources": [ "ElectricPower" ] }
+        }
+    ]
+})");
+}
+
+} // namespace PyrecodesTemplates
+
+#endif // PYRECODES_TEMPLATES_H

--- a/RecoveryWidgets/pyrecodes/PyrecodesUI.cpp
+++ b/RecoveryWidgets/pyrecodes/PyrecodesUI.cpp
@@ -40,13 +40,92 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <QLabel>
 #include <QPushButton>
 #include <QJsonObject>
+#include <QJsonDocument>
 #include <QFileDialog>
+#include <QMessageBox>
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
 #include <QTabWidget>
 
 #include <SC_FileEdit.h>
 #include <SimCenterWidget.h>
 #include <PyrecodesSystemConfig.h>
 #include <PyrecodesComponentLibrary.h>
+
+// A light, self-contained stylesheet for the pyrecodes UI. Scoped to this
+// widget subtree (set on PyrecodesUI) so it tidies up the look without changing
+// the host application's global style.
+static const char *kPyrecodesStyle = R"(
+QGroupBox {
+    font-weight: 600;
+    border: 1px solid #c8ccd1;
+    border-radius: 6px;
+    margin-top: 14px;
+    padding: 8px 8px 6px 8px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 10px;
+    padding: 0 4px;
+    color: #2c3e50;
+}
+QTabWidget::pane {
+    border: 1px solid #c8ccd1;
+    border-radius: 6px;
+    top: -1px;
+}
+QTabBar::tab {
+    padding: 7px 18px;
+    margin-right: 2px;
+    border: 1px solid #c8ccd1;
+    border-bottom: none;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    background: #eceff2;
+}
+QTabBar::tab:selected {
+    background: #ffffff;
+    color: #1a5276;
+    font-weight: 600;
+}
+/* the two top-level tabs (Component Library / System Configuration) - wider */
+QTabWidget#pyrecodesMainTabs > QTabBar::tab {
+    min-width: 240px;
+    padding: 10px 36px;
+    font-size: 14px;
+}
+QPushButton {
+    padding: 5px 14px;
+    border: 1px solid #b6bcc2;
+    border-radius: 5px;
+    background: #f5f6f8;
+}
+QPushButton:hover  { background: #e8f0fe; border-color: #5b9bd5; }
+QPushButton:pressed { background: #d6e4f7; }
+QHeaderView::section {
+    background: #eef2f7;
+    padding: 5px;
+    border: none;
+    border-right: 1px solid #d7dbe0;
+    border-bottom: 1px solid #c8ccd1;
+    font-weight: 600;
+    color: #2c3e50;
+}
+QTableWidget {
+    gridline-color: #e4e7ea;
+    alternate-background-color: #f6f8fa;
+    selection-background-color: #d6e4f7;
+    selection-color: #000000;
+}
+QLineEdit, QComboBox, QPlainTextEdit {
+    border: 1px solid #c3c8cd;
+    border-radius: 4px;
+    padding: 3px 5px;
+    background: #ffffff;
+}
+QLineEdit:focus, QComboBox:focus, QPlainTextEdit:focus { border-color: #5b9bd5; }
+)";
 
 PyrecodesUI::PyrecodesUI(QWidget *parent)
    : SimCenterAppWidget(parent)
@@ -57,25 +136,90 @@ PyrecodesUI::PyrecodesUI(QWidget *parent)
   theComponentLibrary = new PyrecodesComponentLibrary();
   theSystemConfiguration = new PyrecodesSystemConfig();
 
-  QTabWidget *theTabWidget = new QTabWidget();  
+  QTabWidget *theTabWidget = new QTabWidget();
+  theTabWidget->setObjectName("pyrecodesMainTabs");
   theTabWidget->addTab(theComponentLibrary, "Component Library");
   theTabWidget->addTab(theSystemConfiguration, "System Configuration");
-  
+
+  //
+  // "Generate Main File" row: writes the small pyrecodes Main file that ties
+  // the saved Component Library and System Configuration together into a
+  // runnable input set.
+  //
+
+  QLabel *mainHint = new QLabel("Step 3 – once both files above are saved, generate the pyrecodes Main file that links them:");
+  mainHint->setWordWrap(true);
+  mainHint->setStyleSheet("color: #555; font-style: italic;");
+
+  QPushButton *generateMainButton = new QPushButton("Generate Main File…");
+  generateMainButton->setToolTip("Write the pyrecodes Main JSON that references the saved Component\n"
+				 "Library and System Configuration files (the third input pyrecodes needs).");
+
+  connect(generateMainButton, &QPushButton::clicked, this, [=]() {
+
+    QString clPath = theComponentLibrary->getFileName();
+    QString scPath = theSystemConfiguration->getFileName();
+
+    if (clPath.isEmpty() || clPath == "<template>" ||
+	scPath.isEmpty() || scPath == "<template>") {
+      QMessageBox::warning(this, "Generate Main File",
+	"Please Save the Component Library and the System Configuration to files first.\n\n"
+	"The Main file references them by path, so they must exist on disk.");
+      return;
+    }
+
+    QString mainName = QFileDialog::getSaveFileName(this, "Save Main File", "Main.json",
+						    "JSON files (*.json);;All files (*)");
+    if (mainName.isEmpty())
+      return;
+
+    QDir mainDir = QFileInfo(mainName).dir();
+
+    QJsonObject cl;
+    cl["ComponentLibraryCreatorFileName"]  = "json_component_library_creator";
+    cl["ComponentLibraryCreatorClassName"] = "JSONComponentLibraryCreator";
+    cl["ComponentLibraryFile"]             = mainDir.relativeFilePath(clPath);
+
+    QJsonObject sys;
+    sys["SystemCreatorClassName"]   = "ConcreteSystemCreator";
+    sys["SystemCreatorFileName"]    = "concrete_system_creator";
+    sys["SystemClassName"]          = "BuiltEnvironment";
+    sys["SystemFileName"]           = "built_environment";
+    sys["SystemConfigurationFile"]  = mainDir.relativeFilePath(scPath);
+
+    QJsonObject mainObj;
+    mainObj["ComponentLibrary"] = cl;
+    mainObj["System"]           = sys;
+
+    QFile file(mainName);
+    if (!file.open(QFile::WriteOnly | QFile::Text)) {
+      QMessageBox::warning(this, "Generate Main File", "Could not write file:\n" + mainName);
+      return;
+    }
+    file.write(QJsonDocument(mainObj).toJson());
+    file.close();
+
+    QMessageBox::information(this, "Generate Main File",
+      "Main file written:\n" + mainName + "\n\n"
+      "Run the simulation with:\n"
+      "    from pyrecodes import main\n"
+      "    main.run('" + mainDir.absolutePath() + "/', '" + QFileInfo(mainName).fileName() + "')");
+  });
+
   // label for the citation
   QLabel *citation = new QLabel("Users should cite this as follows: "
 				"Blagojević, Nikola, and Stojadinović, Božidar. (2023). "
 				"pyrecodes: an open-source library for regional recovery simulation and disaster resilience assessment of the built environment (v0.1.0). Chair of Structural Dynamics and Earthquake Engineering, ETH Zurich. https://doi.org/10.5905/ethz-1007-700");
-  
+
   citation->setWordWrap(true);
 
-  mainLayout->addWidget(theTabWidget, 0, 0, 1, 4);
-  mainLayout->addWidget(citation,     1, 0, 1, 2);
+  mainLayout->addWidget(theTabWidget,        0, 0, 1, 4);
+  mainLayout->addWidget(mainHint,            1, 0, 1, 3);
+  mainLayout->addWidget(generateMainButton,  1, 3, 1, 1);
+  mainLayout->addWidget(citation,            2, 0, 1, 4);
   mainLayout->setRowStretch(0, 1);
 
-
-  
-
-  
+  this->setStyleSheet(kPyrecodesStyle);
 }
 
 
@@ -101,7 +245,15 @@ bool PyrecodesUI::inputFromJSON(QJsonObject &jsonObject)
 bool PyrecodesUI::outputToJSON(QJsonObject &jsonObject)
 {
   jsonObject["Application"] = "PyrecodesUI";
-    
+
+  QJsonObject componentLibraryData;
+  theComponentLibrary->outputToJSON(componentLibraryData);
+  jsonObject["componentLibrary"] = componentLibraryData;
+
+  QJsonObject systemData;  
+  theSystemConfiguration->outputToJSON(systemData);
+  jsonObject["systemConfiguration"] = systemData;
+  
   return true;
 }
 

--- a/RecoveryWidgets/pyrecodes/PyrecodesUI.h
+++ b/RecoveryWidgets/pyrecodes/PyrecodesUI.h
@@ -43,6 +43,7 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 class SC_FileEdit;
 class PyrecodesSystemConfig;
+class PyrecodesComponentLibrary;
 
 class PyrecodesUI : public SimCenterAppWidget
 {
@@ -68,7 +69,7 @@ private:
   SC_FileEdit *theComponentLibraryFile;
   SC_FileEdit *theSystemConfigurationFile;
 
-  SimCenterWidget *theComponentLibrary;
+  PyrecodesComponentLibrary *theComponentLibrary;
   PyrecodesSystemConfig *theSystemConfiguration;
 };
 


### PR DESCRIPTION
Build out the pyrecodes recovery widget so users can create runnable pyrecodes 0.3.0 input from R2D (Component Library + System Configuration) and generate the Main file that links them.

- Real option sets for every field (component / recovery / relation / distribution / priority / damage-input / resilience-calculator / subsystem-creator classes), each auto-filling its pyrecodes FileName; single source of truth in new PyrecodesOptions.h.
- System Configuration gains Damage Input and Resilience Calculator tabs; Resources get Group + Distribution-Model drop-downs plus a Parameters field.
- Coordinates edited in their own window (Centroid / GeoJSON / BoundingBox).
- "Load Template" on both tabs (content in new PyrecodesTemplates.h) and a "Generate Main File" button.
- Fidelity fixes: preserve arbitrary Supply/Demand keys (e.g. PostDisasterIncreaseDueToEmergencyCalls) and string-valued DamageInput.Parameters (e.g. FileDamageInput paths).
- UX: per-field tooltips/instructions, user-resizable table columns, alternating rows, wider top tabs, scoped stylesheet.

Verified against pyrecodes 0.3.0: UI round-trips Examples 1/2/3 to identical resilience metrics; all 49 drop-down options resolve to real pyrecodes classes; the generated three-file set runs end to end.